### PR TITLE
Fix namespace deletion due to lacking protobuf

### DIFF
--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package serializer
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+type subsetNegotiatedSerializer struct {
+	accepts []func(info runtime.SerializerInfo) bool
+	runtime.NegotiatedSerializer
+}
+
+func (s subsetNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	base := s.NegotiatedSerializer.SupportedMediaTypes()
+	var filtered []runtime.SerializerInfo
+	for _, info := range base {
+		for _, accept := range s.accepts {
+			if accept(info) {
+				filtered = append(filtered, info)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+// NoProtobuf is a function that disallows the use of protobuf.
+func NoProtobuf(info runtime.SerializerInfo) bool {
+	return info.MediaType != runtime.ContentTypeProtobuf
+}
+
+// SubsetNegotiatedSerializer is a runtime.NegotiatedSerializer that provides a safelisted subset of the
+// media types the provided serializer.CodecFactory provides.
+func SubsetNegotiatedSerializer(codecs serializer.CodecFactory, accepts ...func(info runtime.SerializerInfo) bool) runtime.NegotiatedSerializer {
+	return subsetNegotiatedSerializer{accepts, codecs}
+}
+
+// DefaultSubsetNegotiatedSerializer is the default ironcore serializer that does not use protobuf.
+// Since our types *don't* implement protobuf encoding, and without removing the protobuf support,
+// namespace deletion would fail (see issue https://github.com/kubernetes/kubernetes/issues/86666). As such,
+// until we either enhance content type negotiation or implement protobuf for our types, we have to make
+// use of this for our api group negotiated serializers.
+func DefaultSubsetNegotiatedSerializer(codecs serializer.CodecFactory) runtime.NegotiatedSerializer {
+	return SubsetNegotiatedSerializer(codecs, NoProtobuf)
+}


### PR DESCRIPTION
# Proposed Changes

Add `NegotioatedSerializer` to `apiGroupInfo` in apiserver. The missing protobuf serialization is causing `namespaces` to be stuck in termination when deleted.

/ref https://github.com/kubernetes/kubernetes/issues/86666

Fixes #178 