### PR TITLE
Fix nil pointer for internal LB type handling in api server

### DIFF
--- a/internal/controllers/loadbalancer_controller_test.go
+++ b/internal/controllers/loadbalancer_controller_test.go
@@ -70,4 +70,58 @@ var _ = Describe("LoadBalancerController", func() {
 			},
 		}))
 	})
+
+	It("should reconcile an internal load balancer", func(ctx SpecContext) {
+		By("creating an internal load balancer")
+		loadBalancer := &v1alpha1.LoadBalancer{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "load-balancer-",
+			},
+			Spec: v1alpha1.LoadBalancerSpec{
+				Type:       v1alpha1.LoadBalancerTypeInternal,
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []v1alpha1.LoadBalancerIP{
+					{
+						Name:     "ip-1",
+						IPFamily: corev1.IPv4Protocol,
+					},
+				},
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
+				},
+				Template: v1alpha1.InstanceTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, loadBalancer)).To(Succeed())
+		ips := v1alpha1.GetLoadBalancerIPs(loadBalancer)
+
+		By("waiting for the internal load balancer to create a daemon set")
+		daemonSet := &v1alpha1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      v1alpha1.LoadBalancerDaemonSetName(loadBalancer.Name),
+			},
+		}
+		Eventually(Object(daemonSet)).Should(HaveField("Spec", v1alpha1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+			Template: v1alpha1.InstanceTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"},
+				},
+				Spec: v1alpha1.InstanceSpec{
+					Type:             v1alpha1.InstanceTypeLoadBalancer,
+					LoadBalancerType: v1alpha1.LoadBalancerTypeInternal,
+					NetworkRef:       corev1.LocalObjectReference{Name: network.Name},
+					IPs:              ips,
+				},
+			},
+		}))
+	})
 })

--- a/internal/registry/loadbalancer/storage.go
+++ b/internal/registry/loadbalancer/storage.go
@@ -64,7 +64,7 @@ type REST struct {
 func (r *REST) beginCreate(ctx context.Context, obj runtime.Object, opts *metav1.CreateOptions) (genericregistry.FinishFunc, error) {
 	loadBalancer := obj.(*core.LoadBalancer)
 
-	if loadBalancer.Spec.Type != core.LoadBalancerTypePublic {
+	if loadBalancer.Spec.Type != core.LoadBalancerTypePublic && loadBalancer.Spec.Type != core.LoadBalancerTypeInternal {
 		return nil, nil
 	}
 
@@ -88,7 +88,7 @@ func (r *REST) beginUpdate(ctx context.Context, obj, oldObj runtime.Object, opts
 	newLoadBalancer := obj.(*core.LoadBalancer)
 	oldLoadBalancer := oldObj.(*core.LoadBalancer)
 
-	if newLoadBalancer.Spec.Type != core.LoadBalancerTypePublic {
+	if newLoadBalancer.Spec.Type != core.LoadBalancerTypePublic && newLoadBalancer.Spec.Type != core.LoadBalancerTypeInternal {
 		return nil, nil
 	}
 
@@ -110,7 +110,7 @@ func (r *REST) beginUpdate(ctx context.Context, obj, oldObj runtime.Object, opts
 func (r *REST) afterDelete(obj runtime.Object, opts *metav1.DeleteOptions) {
 	loadBalancer := obj.(*core.LoadBalancer)
 
-	if loadBalancer.Spec.Type != core.LoadBalancerTypePublic {
+	if loadBalancer.Spec.Type != core.LoadBalancerTypePublic && loadBalancer.Spec.Type != core.LoadBalancerTypeInternal {
 		return
 	}
 


### PR DESCRIPTION
# Proposed Changes

Fix a nil pointer error which occurs when trying to create a `LoadBalancer` of type `Internal`.

Fixes #206

/cc @kasabe28 @balpert89 