### PR TITLE
Bump `golangci-lint` to v1.55.2 in GH workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.55.2


### PR DESCRIPTION
# Proposed Changes

Bump `golangci-lint` to v1.55.2 in GH workflow.