### PR TITLE
Fix NATReconciler to modify NATTable of NIC belonging to NATs Network

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -63,6 +63,7 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctx := ctrl.SetupSignalHandler()
 
 	cfg, err := configutils.GetConfig()
 	if err != nil {
@@ -166,7 +167,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := ctrl.SetupSignalHandler()
 	if err := apinetclient.SetupNetworkInterfaceNetworkNameFieldIndexer(ctx, mgr.GetFieldIndexer()); err != nil {
 		setupLog.Error(err, "unable to setup field indexer", "field", apinetclient.NetworkInterfaceSpecNetworkRefNameField)
 		os.Exit(1)

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/configutils"
 	ironcorenetv1alpha1 "github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
+	apinetclient "github.com/ironcore-dev/ironcore-net/internal/client"
 	"github.com/ironcore-dev/ironcore-net/internal/controllers"
 	ironcorenet "github.com/ironcore-dev/ironcore-net/internal/controllers/certificate/ironcore-net"
 	"github.com/ironcore-dev/ironcore-net/internal/controllers/scheduler"
@@ -162,6 +163,12 @@ func main() {
 		Cache:         schedulerCache,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Scheduler")
+		os.Exit(1)
+	}
+
+	ctx := ctrl.SetupSignalHandler()
+	if err := apinetclient.SetupNetworkInterfaceNetworkNameFieldIndexer(ctx, mgr.GetFieldIndexer()); err != nil {
+		setupLog.Error(err, "unable to setup field indexer", "field", apinetclient.NetworkInterfaceSpecNetworkRefNameField)
 		os.Exit(1)
 	}
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const NetworkInterfaceSpecNetworkRefNameField = "spec.networkRef.name"
+
 func ClaimNetworkInterfaceNAT(
 	ctx context.Context,
 	c client.Client,
@@ -124,5 +126,12 @@ func ReleaseNetworkInterfaceNAT(ctx context.Context, c client.Client, nic *v1alp
 			return fmt.Errorf("error releasing network interface: %w", err)
 		}
 		return nil
+	})
+}
+
+func SetupNetworkInterfaceNetworkNameFieldIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &v1alpha1.NetworkInterface{}, NetworkInterfaceSpecNetworkRefNameField, func(obj client.Object) []string {
+		nic := obj.(*v1alpha1.NetworkInterface)
+		return []string{nic.Spec.NetworkRef.Name}
 	})
 }

--- a/internal/controllers/controllers_suite_test.go
+++ b/internal/controllers/controllers_suite_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/buildutils"
 	"github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
+	apinetclient "github.com/ironcore-dev/ironcore-net/internal/client"
 	ironcorenet "github.com/ironcore-dev/ironcore-net/internal/controllers/certificate/ironcore-net"
 	"github.com/ironcore-dev/ironcore-net/internal/controllers/scheduler"
 	"github.com/ironcore-dev/ironcore-net/utils/expectations"
@@ -171,6 +172,9 @@ var _ = BeforeSuite(func() {
 
 	mgrCtx, cancel := context.WithCancel(context.Background())
 	DeferCleanup(cancel)
+
+	Expect(apinetclient.SetupNetworkInterfaceNetworkNameFieldIndexer(mgrCtx, k8sManager.GetFieldIndexer())).To(Succeed())
+
 	go func() {
 		defer GinkgoRecover()
 		Expect(k8sManager.Start(mgrCtx)).To(Succeed(), "failed to start manager")

--- a/internal/controllers/natgateway_controller.go
+++ b/internal/controllers/natgateway_controller.go
@@ -159,32 +159,12 @@ func (r *NATGatewayReconciler) manageNATTable(
 	ips []net.IP,
 	existingAllocByNicID map[types.UID]natIPAllocation,
 ) (used, requests int64, err error) {
-	natGatewayList := &v1alpha1.NATGatewayList{}
-	if err := r.List(ctx, natGatewayList,
-		client.InNamespace(natGateway.Namespace),
-	); err != nil {
-		return 0, 0, fmt.Errorf("error listing nat gatway: %w", err)
-	}
-
-	networkList := make(map[string]struct{})
-	for _, nat := range natGatewayList.Items {
-		if nat.Spec.NetworkRef.Name != "" {
-			networkList[nat.Spec.NetworkRef.Name] = struct{}{}
-		}
-	}
-
 	nicList := &v1alpha1.NetworkInterfaceList{}
 	if err := r.List(ctx, nicList,
 		client.InNamespace(natGateway.Namespace),
+		client.MatchingFields{apinetclient.NetworkInterfaceSpecNetworkRefNameField: natGateway.Spec.NetworkRef.Name},
 	); err != nil {
 		return 0, 0, fmt.Errorf("error listing network interfaces: %w", err)
-	}
-
-	nattableNicList := &v1alpha1.NetworkInterfaceList{}
-	for _, nic := range nicList.Items {
-		if _, ok := networkList[nic.Spec.NetworkRef.Name]; ok {
-			nattableNicList.Items = append(nattableNicList.Items, nic)
-		}
 	}
 
 	var (
@@ -206,7 +186,7 @@ func (r *NATGatewayReconciler) manageNATTable(
 		processFree    []int
 		errs           []error
 	)
-	for i, nic := range nattableNicList.Items {
+	for i, nic := range nicList.Items {
 		claimer := v1alpha1.GetNetworkInterfaceNATClaimer(&nic, natGateway.Spec.IPFamily)
 		if claimer != nil {
 			if claimer.UID != natGateway.UID {
@@ -251,7 +231,7 @@ func (r *NATGatewayReconciler) manageNATTable(
 
 	var full bool
 	for _, i := range processClaimed {
-		nic := nattableNicList.Items[i]
+		nic := nicList.Items[i]
 
 		if !full {
 			ip, port, endPort, ok := mgr.UseNextFree()
@@ -292,7 +272,7 @@ func (r *NATGatewayReconciler) manageNATTable(
 			}
 		)
 		for _, i := range processFree {
-			nic := nattableNicList.Items[i]
+			nic := nicList.Items[i]
 
 			if shouldUseNextFree {
 				var ok bool


### PR DESCRIPTION
# Proposed Changes

- Modify NATTable logic to list all in-namespace NICs belonging to NATs Network
- Modify NATReconciler test to create network without NAT and NIC referring to without NAT network. And validate result to have only NAT Network NIC to be in NATTable.

Fixes #181 