### PR TITLE
Fix: use APINetClient for listing network policies for the network

### DIFF
--- a/apinetlet/controllers/networkpolicy_controller.go
+++ b/apinetlet/controllers/networkpolicy_controller.go
@@ -467,7 +467,7 @@ func (r *NetworkPolicyReconciler) enqueueByNetwork() handler.EventHandler {
 		apiNetNetwork := obj.(*apinetv1alpha1.Network)
 
 		networkPolicyList := &apinetv1alpha1.NetworkPolicyList{}
-		if err := r.List(ctx, networkPolicyList,
+		if err := r.APINetClient.List(ctx, networkPolicyList,
 			client.InNamespace(apiNetNetwork.Namespace),
 			client.MatchingFields{apinetletclient.NetworkPolicyNetworkNameField: apiNetNetwork.Name},
 		); err != nil {
@@ -487,7 +487,7 @@ func (r *NetworkPolicyReconciler) enqueueByNetworkInterface() handler.EventHandl
 			client.InNamespace(nic.Namespace),
 			client.MatchingFields{apinetletclient.NetworkPolicyNetworkNameField: nic.Spec.NetworkRef.Name},
 		); err != nil {
-			log.Error(err, "Error listing apinent network policies for nic")
+			log.Error(err, "Error listing apinet network policies for nic")
 			return nil
 		}
 


### PR DESCRIPTION
Updates the `enqueueByNetwork` method in the network policy controller to use `APINetClient.List` instead of `r.List` for listing network policies, fixing the error during the listing process.