### PR TITLE
Harmonize imports, func layout and log usage in `apinetlet` controllers

### DIFF
--- a/apinetlet/controllers/loadbalancer_controller.go
+++ b/apinetlet/controllers/loadbalancer_controller.go
@@ -174,11 +174,7 @@ func (r *LoadBalancerReconciler) reconcile(ctx context.Context, log logr.Logger,
 	return ctrl.Result{}, nil
 }
 
-func (r *LoadBalancerReconciler) manageAPINetLoadBalancerRouting(
-	ctx context.Context,
-	loadBalancer *networkingv1alpha1.LoadBalancer,
-	apiNetLoadBalancer *apinetv1alpha1.LoadBalancer,
-) error {
+func (r *LoadBalancerReconciler) manageAPINetLoadBalancerRouting(ctx context.Context, loadBalancer *networkingv1alpha1.LoadBalancer, apiNetLoadBalancer *apinetv1alpha1.LoadBalancer) error {
 	loadBalancerRouting := &networkingv1alpha1.LoadBalancerRouting{}
 	if err := r.Get(ctx, client.ObjectKeyFromObject(loadBalancer), loadBalancerRouting); client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("error getting load balancer routing: %w", err)
@@ -227,9 +223,7 @@ func (r *LoadBalancerReconciler) manageAPINetLoadBalancerRouting(
 	return nil
 }
 
-func (r *LoadBalancerReconciler) getPublicLoadBalancerAPINetIPs(
-	loadBalancer *networkingv1alpha1.LoadBalancer,
-) []*apinetv1alpha1ac.LoadBalancerIPApplyConfiguration {
+func (r *LoadBalancerReconciler) getPublicLoadBalancerAPINetIPs(loadBalancer *networkingv1alpha1.LoadBalancer) []*apinetv1alpha1ac.LoadBalancerIPApplyConfiguration {
 	res := make([]*apinetv1alpha1ac.LoadBalancerIPApplyConfiguration, len(loadBalancer.Spec.IPFamilies))
 	for i, ipFamily := range loadBalancer.Spec.IPFamilies {
 		res[i] = apinetv1alpha1ac.LoadBalancerIP().
@@ -239,10 +233,7 @@ func (r *LoadBalancerReconciler) getPublicLoadBalancerAPINetIPs(
 	return res
 }
 
-func (r *LoadBalancerReconciler) getInternalLoadBalancerAPINetIPs(
-	ctx context.Context,
-	loadBalancer *networkingv1alpha1.LoadBalancer,
-) ([]*apinetv1alpha1ac.LoadBalancerIPApplyConfiguration, error) {
+func (r *LoadBalancerReconciler) getInternalLoadBalancerAPINetIPs(ctx context.Context, loadBalancer *networkingv1alpha1.LoadBalancer) ([]*apinetv1alpha1ac.LoadBalancerIPApplyConfiguration, error) {
 	var ips []*apinetv1alpha1ac.LoadBalancerIPApplyConfiguration
 	for i, ip := range loadBalancer.Spec.IPs {
 		switch {

--- a/apinetlet/controllers/loadbalancer_controller.go
+++ b/apinetlet/controllers/loadbalancer_controller.go
@@ -9,7 +9,8 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/ironcore-dev/controller-utils/clientutils"
+	"golang.org/x/exp/slices"
+
 	apinetv1alpha1 "github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
 	"github.com/ironcore-dev/ironcore-net/apimachinery/api/net"
 	apinetletclient "github.com/ironcore-dev/ironcore-net/apinetlet/client"
@@ -18,11 +19,12 @@ import (
 	apinetv1alpha1ac "github.com/ironcore-dev/ironcore-net/client-go/applyconfigurations/core/v1alpha1"
 	metav1ac "github.com/ironcore-dev/ironcore-net/client-go/applyconfigurations/meta/v1"
 	"github.com/ironcore-dev/ironcore-net/client-go/ironcorenet"
+
+	"github.com/ironcore-dev/controller-utils/clientutils"
 	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	ipamv1alpha1 "github.com/ironcore-dev/ironcore/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	"github.com/ironcore-dev/ironcore/utils/predicates"
-	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/apinetlet/controllers/network_controller.go
+++ b/apinetlet/controllers/network_controller.go
@@ -66,15 +66,15 @@ func (r *NetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *NetworkReconciler) deleteGone(ctx context.Context, log logr.Logger, networkKey client.ObjectKey) (ctrl.Result, error) {
 	log.V(1).Info("Delete gone")
 
-	log.V(1).Info("Deleting any matching apinet networks")
+	log.V(1).Info("Deleting any matching APINet networks")
 	if err := r.APINetClient.DeleteAllOf(ctx, &apinetv1alpha1.Network{},
 		client.InNamespace(r.APINetNamespace),
 		apinetletclient.MatchingSourceKeyLabels(r.Scheme(), r.RESTMapper(), networkKey, &networkingv1alpha1.Network{}),
 	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("error deleting apinet networks: %w", err)
+		return ctrl.Result{}, fmt.Errorf("error deleting APINet networks: %w", err)
 	}
 
-	log.V(1).Info("Issued delete for any leftover apinet network")
+	log.V(1).Info("Issued delete for any leftover APINet network")
 	return ctrl.Result{}, nil
 }
 
@@ -94,7 +94,7 @@ func (r *NetworkReconciler) delete(ctx context.Context, log logr.Logger, network
 		return ctrl.Result{}, nil
 	}
 
-	log.V(1).Info("Deleting target apinet network if any")
+	log.V(1).Info("Deleting target APINet network if any")
 	apiNetNetwork := &apinetv1alpha1.Network{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: r.APINetNamespace,
@@ -103,10 +103,10 @@ func (r *NetworkReconciler) delete(ctx context.Context, log logr.Logger, network
 	}
 	if err := r.APINetClient.Delete(ctx, apiNetNetwork); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("error deleting target apinet network: %w", err)
+			return ctrl.Result{}, fmt.Errorf("error deleting target APINet network: %w", err)
 		}
 
-		log.V(1).Info("Target apinet network is gone, removing finalizer")
+		log.V(1).Info("Target APINet network is gone, removing finalizer")
 		if err := clientutils.PatchRemoveFinalizer(ctx, r.Client, network, networkFinalizer); err != nil {
 			return ctrl.Result{}, fmt.Errorf("error removing finalizer: %w", err)
 		}
@@ -114,7 +114,7 @@ func (r *NetworkReconciler) delete(ctx context.Context, log logr.Logger, network
 		return ctrl.Result{}, nil
 	}
 
-	log.V(1).Info("Target apinet network is not yet gone, requeueing")
+	log.V(1).Info("Target APINet network is not yet gone, requeueing")
 	return ctrl.Result{Requeue: true}, nil
 }
 
@@ -148,7 +148,7 @@ func (r *NetworkReconciler) reconcile(ctx context.Context, log logr.Logger, netw
 				log.Error(err, "Error updating network state")
 			}
 		}
-		return ctrl.Result{}, fmt.Errorf("error applying apinet network: %w", err)
+		return ctrl.Result{}, fmt.Errorf("error applying APINet network: %w", err)
 	}
 	log = log.WithValues("ID", apiNetNetwork.Spec.ID)
 	log.V(1).Info("Applied APINet network")
@@ -201,10 +201,10 @@ func (r *NetworkReconciler) applyAPINetNetwork(ctx context.Context, log logr.Log
 
 	var peerings []apinetv1alpha1.NetworkPeering
 	for _, peeringClaimRef := range network.Spec.PeeringClaimRefs {
-		log.V(1).Info("Get apinet network for target network")
+		log.V(1).Info("Get APINet network for target network")
 		targetApinetNetwork := &apinetv1alpha1.Network{}
 		if err := r.APINetClient.Get(ctx, client.ObjectKey{Namespace: r.APINetNamespace, Name: string(peeringClaimRef.UID)}, targetApinetNetwork); err != nil {
-			log.V(1).Info("target apinet network is not created yet")
+			log.V(1).Info("target APINet network is not created yet")
 			break
 		}
 
@@ -218,7 +218,7 @@ func (r *NetworkReconciler) applyAPINetNetwork(ctx context.Context, log logr.Log
 		if idx != -1 {
 			peeringPrefixes, err := r.getAPINetNetworkPeeringPrefixes(ctx, network.Spec.Peerings[idx].Prefixes, network.Namespace)
 			if err != nil {
-				return nil, fmt.Errorf("error getting apinet network peering prefixes: %w", err)
+				return nil, fmt.Errorf("error getting APINet network peering prefixes: %w", err)
 			}
 
 			peerings = append(peerings, apinetv1alpha1.NetworkPeering{
@@ -232,7 +232,7 @@ func (r *NetworkReconciler) applyAPINetNetwork(ctx context.Context, log logr.Log
 
 	log.V(1).Info("Applying APINet network")
 	if err := r.APINetClient.Patch(ctx, apiNetNetwork, client.Apply, fieldOwner, client.ForceOwnership); err != nil {
-		return nil, fmt.Errorf("error applying apinet network: %w", err)
+		return nil, fmt.Errorf("error applying APINet network: %w", err)
 	}
 	return apiNetNetwork, nil
 }

--- a/apinetlet/controllers/network_controller.go
+++ b/apinetlet/controllers/network_controller.go
@@ -9,11 +9,13 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
-	"github.com/ironcore-dev/controller-utils/clientutils"
+
 	apinetv1alpha1 "github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
 	apinetletclient "github.com/ironcore-dev/ironcore-net/apinetlet/client"
 	"github.com/ironcore-dev/ironcore-net/apinetlet/handler"
 	"github.com/ironcore-dev/ironcore-net/apinetlet/provider"
+
+	"github.com/ironcore-dev/controller-utils/clientutils"
 	ipamv1alpha1 "github.com/ironcore-dev/ironcore/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	"github.com/ironcore-dev/ironcore/utils/predicates"
@@ -235,8 +237,7 @@ func (r *NetworkReconciler) applyAPINetNetwork(ctx context.Context, log logr.Log
 	return apiNetNetwork, nil
 }
 
-func (r *NetworkReconciler) getAPINetNetworkPeeringPrefixes(ctx context.Context, peeringPrefixes []networkingv1alpha1.PeeringPrefix,
-	networkNamespace string) ([]apinetv1alpha1.PeeringPrefix, error) {
+func (r *NetworkReconciler) getAPINetNetworkPeeringPrefixes(ctx context.Context, peeringPrefixes []networkingv1alpha1.PeeringPrefix, networkNamespace string) ([]apinetv1alpha1.PeeringPrefix, error) {
 	apinetPeeringPrefixes := []apinetv1alpha1.PeeringPrefix{}
 	for _, prefix := range peeringPrefixes {
 		if prefix.Prefix != nil {

--- a/apinetlet/controllers/networkinterface_controller.go
+++ b/apinetlet/controllers/networkinterface_controller.go
@@ -70,7 +70,7 @@ func (r *NetworkInterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 
 		if err := r.releaseNetworkInterfaceKeyAPINetInterfaces(ctx, req.NamespacedName); err != nil {
-			return ctrl.Result{}, fmt.Errorf("error releasing apinet network interfaces by key: %w", err)
+			return ctrl.Result{}, fmt.Errorf("error releasing APINet network interfaces by key: %w", err)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -91,7 +91,7 @@ func (r *NetworkInterfaceReconciler) releaseNetworkInterfaceKeyAPINetInterfaces(
 		client.InNamespace(r.APINetNamespace),
 		apinetletclient.MatchingSourceKeyLabels(r.Scheme(), r.RESTMapper(), nicKey, &networkingv1alpha1.NetworkInterface{}),
 	); err != nil {
-		return fmt.Errorf("error listing apinet network interfaces: %w", err)
+		return fmt.Errorf("error listing APINet network interfaces: %w", err)
 	}
 
 	var errs []error
@@ -116,7 +116,7 @@ func (r *NetworkInterfaceReconciler) releaseNetworkInterfaceAPINetNetworkInterfa
 		client.InNamespace(r.APINetNamespace),
 		apinetletclient.MatchingSourceLabels(r.Scheme(), r.RESTMapper(), nic),
 	); err != nil {
-		return fmt.Errorf("error listing apinet network interfaces: %w", err)
+		return fmt.Errorf("error listing APINet network interfaces: %w", err)
 	}
 
 	// create a shallow copy of the network interface with the
@@ -176,7 +176,7 @@ func (r *NetworkInterfaceReconciler) delete(ctx context.Context, log logr.Logger
 	}
 
 	if err := r.releaseNetworkInterfaceAPINetNetworkInterfaces(ctx, nic); err != nil {
-		return ctrl.Result{}, fmt.Errorf("error releasing apinet network interfaces: %w", err)
+		return ctrl.Result{}, fmt.Errorf("error releasing APINet network interfaces: %w", err)
 	}
 	log.V(1).Info("Released APINet network interfaces")
 
@@ -335,7 +335,7 @@ func (r *NetworkInterfaceReconciler) getAPINetNetworkInterfaceForNetworkInterfac
 	if err := r.APINetClient.List(ctx, apiNetNicList,
 		client.InNamespace(r.APINetNamespace),
 	); err != nil {
-		return nil, fmt.Errorf("error listing apinet network interfaces: %w", err)
+		return nil, fmt.Errorf("error listing APINet network interfaces: %w", err)
 	}
 
 	var (
@@ -479,7 +479,7 @@ func (r *NetworkInterfaceReconciler) reconcile(ctx context.Context, log logr.Log
 	}
 
 	if err := r.manageAPINetNetworkInterface(ctx, nic, apiNetNic, vips, prefixes); err != nil {
-		return ctrl.Result{}, fmt.Errorf("error managing apinet network interface: %w", err)
+		return ctrl.Result{}, fmt.Errorf("error managing APINet network interface: %w", err)
 	}
 
 	var (

--- a/apinetlet/controllers/networkinterface_controller.go
+++ b/apinetlet/controllers/networkinterface_controller.go
@@ -9,14 +9,17 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/ironcore-dev/controller-utils/clientutils"
-	"github.com/ironcore-dev/controller-utils/metautils"
+	"golang.org/x/exp/slices"
+
 	apinetv1alpha1 "github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
 	"github.com/ironcore-dev/ironcore-net/apimachinery/api/net"
 	apinetletclient "github.com/ironcore-dev/ironcore-net/apinetlet/client"
 	apinetlethandler "github.com/ironcore-dev/ironcore-net/apinetlet/handler"
 	"github.com/ironcore-dev/ironcore-net/apinetlet/provider"
 	utilgeneric "github.com/ironcore-dev/ironcore-net/utils/generic"
+
+	"github.com/ironcore-dev/controller-utils/clientutils"
+	"github.com/ironcore-dev/controller-utils/metautils"
 	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	ipamv1alpha1 "github.com/ironcore-dev/ironcore/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
@@ -24,7 +27,6 @@ import (
 	"github.com/ironcore-dev/ironcore/utils/generic"
 	"github.com/ironcore-dev/ironcore/utils/predicates"
 	utilslices "github.com/ironcore-dev/ironcore/utils/slices"
-	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/apinetlet/controllers/networkinterface_controller.go
+++ b/apinetlet/controllers/networkinterface_controller.go
@@ -330,11 +330,7 @@ func (r *NetworkInterfaceReconciler) networkInterfaceAPINetNetworkInterfaceSelec
 	})
 }
 
-func (r *NetworkInterfaceReconciler) getAPINetNetworkInterfaceForNetworkInterface(
-	ctx context.Context,
-	log logr.Logger,
-	nic *networkingv1alpha1.NetworkInterface,
-) (*apinetv1alpha1.NetworkInterface, error) {
+func (r *NetworkInterfaceReconciler) getAPINetNetworkInterfaceForNetworkInterface(ctx context.Context, log logr.Logger, nic *networkingv1alpha1.NetworkInterface) (*apinetv1alpha1.NetworkInterface, error) {
 	apiNetNicList := &apinetv1alpha1.NetworkInterfaceList{}
 	if err := r.APINetClient.List(ctx, apiNetNicList,
 		client.InNamespace(r.APINetNamespace),
@@ -363,10 +359,7 @@ func (r *NetworkInterfaceReconciler) getAPINetNetworkInterfaceForNetworkInterfac
 	return foundAPINetNic, errors.Join(errs...)
 }
 
-func (r *NetworkInterfaceReconciler) getPrefixesForNetworkInterface(
-	ctx context.Context,
-	nic *networkingv1alpha1.NetworkInterface,
-) ([]net.IPPrefix, error) {
+func (r *NetworkInterfaceReconciler) getPrefixesForNetworkInterface(ctx context.Context, nic *networkingv1alpha1.NetworkInterface) ([]net.IPPrefix, error) {
 	var res []net.IPPrefix
 	for idx, prefixSrc := range nic.Spec.Prefixes {
 		switch {
@@ -392,13 +385,7 @@ func (r *NetworkInterfaceReconciler) getPrefixesForNetworkInterface(
 	return res, nil
 }
 
-func (r *NetworkInterfaceReconciler) manageAPINetNetworkInterface(
-	ctx context.Context,
-	nic *networkingv1alpha1.NetworkInterface,
-	apiNetNic *apinetv1alpha1.NetworkInterface,
-	vips []networkingv1alpha1.VirtualIP,
-	prefixes []net.IPPrefix,
-) error {
+func (r *NetworkInterfaceReconciler) manageAPINetNetworkInterface(ctx context.Context, nic *networkingv1alpha1.NetworkInterface, apiNetNic *apinetv1alpha1.NetworkInterface, vips []networkingv1alpha1.VirtualIP, prefixes []net.IPPrefix) error {
 	_ = nic
 
 	var (
@@ -434,10 +421,7 @@ func (r *NetworkInterfaceReconciler) manageAPINetNetworkInterface(
 	return r.APINetClient.Patch(ctx, apiNetNic, client.StrategicMergeFrom(base))
 }
 
-func (r *NetworkInterfaceReconciler) setNetworkInterfacePending(
-	ctx context.Context,
-	nic *networkingv1alpha1.NetworkInterface,
-) error {
+func (r *NetworkInterfaceReconciler) setNetworkInterfacePending(ctx context.Context, nic *networkingv1alpha1.NetworkInterface) error {
 	now := metav1.Now()
 
 	base := nic.DeepCopy()
@@ -515,14 +499,7 @@ func (r *NetworkInterfaceReconciler) reconcile(ctx context.Context, log logr.Log
 	return ctrl.Result{}, nil
 }
 
-func (r *NetworkInterfaceReconciler) updateNetworkInterfaceStatus(
-	ctx context.Context,
-	nic *networkingv1alpha1.NetworkInterface,
-	state networkingv1alpha1.NetworkInterfaceState,
-	ips []commonv1alpha1.IP,
-	prefixes []commonv1alpha1.IPPrefix,
-	virtualIP *commonv1alpha1.IP,
-) error {
+func (r *NetworkInterfaceReconciler) updateNetworkInterfaceStatus(ctx context.Context, nic *networkingv1alpha1.NetworkInterface, state networkingv1alpha1.NetworkInterfaceState, ips []commonv1alpha1.IP, prefixes []commonv1alpha1.IPPrefix, virtualIP *commonv1alpha1.IP) error {
 	now := metav1.Now()
 	base := nic.DeepCopy()
 
@@ -540,13 +517,7 @@ func (r *NetworkInterfaceReconciler) updateNetworkInterfaceStatus(
 	return nil
 }
 
-func NetworkInterfaceStatusUpToDate(
-	nic *networkingv1alpha1.NetworkInterface,
-	expectedState networkingv1alpha1.NetworkInterfaceState,
-	expectedIPs []commonv1alpha1.IP,
-	expectedIPPrefixes []commonv1alpha1.IPPrefix,
-	expectedVirtualIP *commonv1alpha1.IP,
-) bool {
+func NetworkInterfaceStatusUpToDate(nic *networkingv1alpha1.NetworkInterface, expectedState networkingv1alpha1.NetworkInterfaceState, expectedIPs []commonv1alpha1.IP, expectedIPPrefixes []commonv1alpha1.IPPrefix, expectedVirtualIP *commonv1alpha1.IP) bool {
 	return nic.Status.State == expectedState &&
 		slices.Equal(nic.Status.IPs, expectedIPs) &&
 		slices.Equal(nic.Status.Prefixes, expectedIPPrefixes) &&

--- a/apinetlet/controllers/networkpolicy_controller.go
+++ b/apinetlet/controllers/networkpolicy_controller.go
@@ -300,7 +300,7 @@ func (r *NetworkPolicyReconciler) processObjectSelector(ctx context.Context, np 
 		return r.fetchIPsFromNetworkInterfaces(ctx, np, objectSelector)
 	case "LoadBalancer":
 		return r.fetchIPsFromLoadBalancers(ctx, np, objectSelector)
-	//TODO: add more objects selector support if needed
+	// TODO: add more objects selector support if needed
 	default:
 		return nil, fmt.Errorf("unsupported object kind: %s", objectSelector.Kind)
 	}
@@ -349,7 +349,7 @@ func (r *NetworkPolicyReconciler) fetchIPsFromLoadBalancers(ctx context.Context,
 		return nil, err
 	}
 
-	//TODO: apinet load balancer need to inherit labels from ironcore load balancer
+	// TODO: apinet load balancer need to inherit labels from ironcore load balancer
 	lbList := &apinetv1alpha1.LoadBalancerList{}
 	if err := r.List(ctx, lbList,
 		client.InNamespace(np.Namespace),
@@ -361,7 +361,7 @@ func (r *NetworkPolicyReconciler) fetchIPsFromLoadBalancers(ctx context.Context,
 	var ips []apinetv1alpha1.ObjectIP
 
 	for _, lb := range lbList.Items {
-		//TODO: handle loadbalancer ports
+		// TODO: handle loadbalancer ports
 		for _, ip := range lb.Spec.IPs {
 			// TODO: handle LoadBalancerIP when only IPFamily is specified to allocate a random IP.
 			ips = append(ips, apinetv1alpha1.ObjectIP{
@@ -374,14 +374,7 @@ func (r *NetworkPolicyReconciler) fetchIPsFromLoadBalancers(ctx context.Context,
 	return ips, nil
 }
 
-func (r *NetworkPolicyReconciler) applyNetworkPolicyRule(
-	ctx context.Context,
-	networkPolicy *networkingv1alpha1.NetworkPolicy,
-	apiNetNetworkPolicy *apinetv1alpha1.NetworkPolicy,
-	targets []apinetv1alpha1.TargetNetworkInterface,
-	network *apinetv1alpha1.Network,
-	ingressRules, egressRules []apinetv1alpha1.Rule,
-) error {
+func (r *NetworkPolicyReconciler) applyNetworkPolicyRule(ctx context.Context, networkPolicy *networkingv1alpha1.NetworkPolicy, apiNetNetworkPolicy *apinetv1alpha1.NetworkPolicy, targets []apinetv1alpha1.TargetNetworkInterface, network *apinetv1alpha1.Network, ingressRules, egressRules []apinetv1alpha1.Rule) error {
 	networkPolicyRule := &apinetv1alpha1.NetworkPolicyRule{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NetworkPolicyRule",
@@ -441,17 +434,16 @@ func (r *NetworkPolicyReconciler) applyAPINetNetworkPolicy(ctx context.Context, 
 
 	nicSelector := translateLabelSelector(networkPolicy.Spec.NetworkInterfaceSelector)
 
-	apiNetNetworkPolicyApplyCfg :=
-		apinetv1alpha1ac.NetworkPolicy(string(networkPolicy.UID), r.APINetNamespace).
-			WithLabels(apinetletclient.SourceLabels(r.Scheme(), r.RESTMapper(), networkPolicy)).
-			WithSpec(apinetv1alpha1ac.NetworkPolicySpec().
-				WithNetworkRef(corev1.LocalObjectReference{Name: apiNetNetworkName}).
-				WithNetworkInterfaceSelector(nicSelector).
-				WithPriority(1000). // set default value since networkingv1alpha1.NetworkPolicy does not have this field
-				WithIngress(apiNetIngressRules...).
-				WithEgress(apiNetEgressRules...).
-				WithPolicyTypes(apiNetNetworkPolicyTypes...),
-			)
+	apiNetNetworkPolicyApplyCfg := apinetv1alpha1ac.NetworkPolicy(string(networkPolicy.UID), r.APINetNamespace).
+		WithLabels(apinetletclient.SourceLabels(r.Scheme(), r.RESTMapper(), networkPolicy)).
+		WithSpec(apinetv1alpha1ac.NetworkPolicySpec().
+			WithNetworkRef(corev1.LocalObjectReference{Name: apiNetNetworkName}).
+			WithNetworkInterfaceSelector(nicSelector).
+			WithPriority(1000). // set default value since networkingv1alpha1.NetworkPolicy does not have this field
+			WithIngress(apiNetIngressRules...).
+			WithEgress(apiNetEgressRules...).
+			WithPolicyTypes(apiNetNetworkPolicyTypes...),
+		)
 	apiNetNetworkPolicy, err := r.APINetInterface.CoreV1alpha1().
 		NetworkPolicies(r.APINetNamespace).
 		Apply(ctx, apiNetNetworkPolicyApplyCfg, metav1.ApplyOptions{FieldManager: string(fieldOwner), Force: true})

--- a/apinetlet/controllers/networkpolicy_controller.go
+++ b/apinetlet/controllers/networkpolicy_controller.go
@@ -8,12 +8,8 @@ import (
 	"fmt"
 	"net/netip"
 
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/util/workqueue"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-
 	"github.com/go-logr/logr"
-	"github.com/ironcore-dev/controller-utils/clientutils"
+
 	apinetv1alpha1 "github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
 	"github.com/ironcore-dev/ironcore-net/apimachinery/api/net"
 	apinetletclient "github.com/ironcore-dev/ironcore-net/apinetlet/client"
@@ -21,19 +17,23 @@ import (
 	apinetv1alpha1ac "github.com/ironcore-dev/ironcore-net/client-go/applyconfigurations/core/v1alpha1"
 	"github.com/ironcore-dev/ironcore-net/client-go/ironcorenet"
 	apinetclient "github.com/ironcore-dev/ironcore-net/internal/client"
+
+	"github.com/ironcore-dev/controller-utils/clientutils"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	"github.com/ironcore-dev/ironcore/utils/predicates"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/workqueue"
+	klog "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )

--- a/apinetlet/controllers/networkpolicy_controller.go
+++ b/apinetlet/controllers/networkpolicy_controller.go
@@ -42,9 +42,7 @@ const (
 	networkPolicyFinalizer = "apinet.ironcore.dev/networkpolicy"
 )
 
-var (
-	networkPolicyFieldOwner = client.FieldOwner(networkingv1alpha1.Resource("networkpolicies").String())
-)
+var networkPolicyFieldOwner = client.FieldOwner(networkingv1alpha1.Resource("networkpolicies").String())
 
 type NetworkPolicyReconciler struct {
 	client.Client
@@ -82,12 +80,12 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *NetworkPolicyReconciler) deleteGone(ctx context.Context, log logr.Logger, networkPolicyKey client.ObjectKey) (ctrl.Result, error) {
 	log.V(1).Info("Delete gone")
 
-	log.V(1).Info("Deleting any matching apinet network policies")
+	log.V(1).Info("Deleting any matching APINet network policies")
 	if err := r.APINetClient.DeleteAllOf(ctx, &apinetv1alpha1.NetworkPolicy{},
 		client.InNamespace(r.APINetNamespace),
 		apinetletclient.MatchingSourceKeyLabels(r.Scheme(), r.RESTMapper(), networkPolicyKey, &networkingv1alpha1.NetworkPolicy{}),
 	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("error deleting apinet network policies: %w", err)
+		return ctrl.Result{}, fmt.Errorf("error deleting APINet network policies: %w", err)
 	}
 
 	log.V(1).Info("Deleted any leftover APINet network policy")
@@ -118,7 +116,7 @@ func (r *NetworkPolicyReconciler) delete(ctx context.Context, log logr.Logger, n
 	}
 	if err := r.APINetClient.Delete(ctx, apiNetNetworkPolicy); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("error deleting apinet network policy: %w", err)
+			return ctrl.Result{}, fmt.Errorf("error deleting APINet network policy: %w", err)
 		}
 	}
 
@@ -164,7 +162,7 @@ func (r *NetworkPolicyReconciler) reconcile(ctx context.Context, log logr.Logger
 	log.V(1).Info("Applying APINet network policy")
 	apiNetNetworkPolicy, err := r.applyAPINetNetworkPolicy(ctx, networkPolicy, apiNetNetworkName)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("error applying apinet network policy: %w", err)
+		return ctrl.Result{}, fmt.Errorf("error applying APINet network policy: %w", err)
 	}
 
 	log.V(1).Info("Finding APINet network interface targets")
@@ -187,7 +185,7 @@ func (r *NetworkPolicyReconciler) reconcile(ctx context.Context, log logr.Logger
 
 	log.V(1).Info("Applying APINet network policy rule", "targets", targets, "Network", klog.KObj(apiNetNetwork))
 	if err := r.applyNetworkPolicyRule(ctx, networkPolicy, apiNetNetworkPolicy, targets, apiNetNetwork, ingressRules, egressRules); err != nil {
-		return ctrl.Result{}, fmt.Errorf("error applying apinet network policy rule: %w", err)
+		return ctrl.Result{}, fmt.Errorf("error applying APINet network policy rule: %w", err)
 	}
 
 	log.V(1).Info("Reconciled")
@@ -206,7 +204,7 @@ func (r *NetworkPolicyReconciler) findTargets(ctx context.Context, apiNetNetwork
 		client.MatchingLabelsSelector{Selector: sel},
 		client.MatchingFields{apinetclient.NetworkInterfaceSpecNetworkRefNameField: apiNetNetworkPolicy.Spec.NetworkRef.Name},
 	); err != nil {
-		return nil, fmt.Errorf("error listing apinet network interfaces: %w", err)
+		return nil, fmt.Errorf("error listing APINet network interfaces: %w", err)
 	}
 
 	// Make slice non-nil so omitempty does not file.
@@ -318,7 +316,7 @@ func (r *NetworkPolicyReconciler) fetchIPsFromNetworkInterfaces(ctx context.Cont
 		client.MatchingLabelsSelector{Selector: sel},
 		client.MatchingFields{apinetclient.NetworkInterfaceSpecNetworkRefNameField: np.Spec.NetworkRef.Name},
 	); err != nil {
-		return nil, fmt.Errorf("error listing apinet network interfaces: %w", err)
+		return nil, fmt.Errorf("error listing APINet network interfaces: %w", err)
 	}
 
 	var ips []apinetv1alpha1.ObjectIP
@@ -448,7 +446,7 @@ func (r *NetworkPolicyReconciler) applyAPINetNetworkPolicy(ctx context.Context, 
 		NetworkPolicies(r.APINetNamespace).
 		Apply(ctx, apiNetNetworkPolicyApplyCfg, metav1.ApplyOptions{FieldManager: string(fieldOwner), Force: true})
 	if err != nil {
-		return nil, fmt.Errorf("error applying apinet network policy: %w", err)
+		return nil, fmt.Errorf("error applying APINet network policy: %w", err)
 	}
 	return apiNetNetworkPolicy, nil
 }
@@ -479,7 +477,7 @@ func (r *NetworkPolicyReconciler) enqueueByNetworkInterface() handler.EventHandl
 			client.InNamespace(nic.Namespace),
 			client.MatchingFields{apinetletclient.NetworkPolicyNetworkNameField: nic.Spec.NetworkRef.Name},
 		); err != nil {
-			log.Error(err, "Error listing apinet network policies for nic")
+			log.Error(err, "Error listing APINet network policies for nic")
 			return nil
 		}
 

--- a/apinetlet/controllers/virtualip_controller.go
+++ b/apinetlet/controllers/virtualip_controller.go
@@ -73,7 +73,7 @@ func (r *VirtualIPReconciler) deleteGone(ctx context.Context, log logr.Logger, v
 		client.InNamespace(r.APINetNamespace),
 		apinetletclient.MatchingSourceKeyLabels(r.Scheme(), r.RESTMapper(), virtualIPKey, &networkingv1alpha1.VirtualIP{}),
 	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("error deleting apinet ips: %w", err)
+		return ctrl.Result{}, fmt.Errorf("error deleting APINet ips: %w", err)
 	}
 
 	log.V(1).Info("Issued delete for any leftover APINet ips")
@@ -109,7 +109,7 @@ func (r *VirtualIPReconciler) delete(ctx context.Context, log logr.Logger, virtu
 	}
 	if err := r.APINetClient.Delete(ctx, apiNetIP); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("error deleting target apinet ip: %w", err)
+			return ctrl.Result{}, fmt.Errorf("error deleting target APINet ip: %w", err)
 		}
 
 		log.V(1).Info("Target APINet ip is gone, removing finalizer")
@@ -144,7 +144,7 @@ func (r *VirtualIPReconciler) reconcile(ctx context.Context, log logr.Logger, vi
 				log.Error(err, "Error patching virtual IP status")
 			}
 		}
-		return ctrl.Result{}, fmt.Errorf("error applying apinet ip: %w", err)
+		return ctrl.Result{}, fmt.Errorf("error applying APINet ip: %w", err)
 	}
 
 	if err := r.patchStatusAllocated(ctx, virtualIP, ip); err != nil {
@@ -166,7 +166,7 @@ func (r *VirtualIPReconciler) applyIP(ctx context.Context, log logr.Logger, virt
 		IPs(r.APINetNamespace).
 		Apply(ctx, apiNetIPApplyCfg, metav1.ApplyOptions{FieldManager: string(fieldOwner), Force: true})
 	if err != nil {
-		return netip.Addr{}, fmt.Errorf("error applying apinet IP: %w", err)
+		return netip.Addr{}, fmt.Errorf("error applying APINet ip: %w", err)
 	}
 
 	log.V(1).Info("Applied APINet ip")

--- a/apinetlet/controllers/virtualip_controller.go
+++ b/apinetlet/controllers/virtualip_controller.go
@@ -9,12 +9,14 @@ import (
 	"net/netip"
 
 	"github.com/go-logr/logr"
-	"github.com/ironcore-dev/controller-utils/clientutils"
+
 	apinetv1alpha1 "github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
 	apinetletclient "github.com/ironcore-dev/ironcore-net/apinetlet/client"
 	"github.com/ironcore-dev/ironcore-net/apinetlet/handler"
 	apinetv1alpha1ac "github.com/ironcore-dev/ironcore-net/client-go/applyconfigurations/core/v1alpha1"
 	"github.com/ironcore-dev/ironcore-net/client-go/ironcorenet"
+
+	"github.com/ironcore-dev/controller-utils/clientutils"
 	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	"github.com/ironcore-dev/ironcore/utils/predicates"
@@ -153,13 +155,12 @@ func (r *VirtualIPReconciler) reconcile(ctx context.Context, log logr.Logger, vi
 }
 
 func (r *VirtualIPReconciler) applyIP(ctx context.Context, log logr.Logger, virtualIP *networkingv1alpha1.VirtualIP) (netip.Addr, error) {
-	apiNetIPApplyCfg :=
-		apinetv1alpha1ac.IP(string(virtualIP.UID), r.APINetNamespace).
-			WithLabels(apinetletclient.SourceLabels(r.Scheme(), r.RESTMapper(), virtualIP)).
-			WithSpec(apinetv1alpha1ac.IPSpec().
-				WithType(apinetv1alpha1.IPTypePublic).
-				WithIPFamily(virtualIP.Spec.IPFamily),
-			)
+	apiNetIPApplyCfg := apinetv1alpha1ac.IP(string(virtualIP.UID), r.APINetNamespace).
+		WithLabels(apinetletclient.SourceLabels(r.Scheme(), r.RESTMapper(), virtualIP)).
+		WithSpec(apinetv1alpha1ac.IPSpec().
+			WithType(apinetv1alpha1.IPTypePublic).
+			WithIPFamily(virtualIP.Spec.IPFamily),
+		)
 
 	apiNetIP, err := r.APINetInterface.CoreV1alpha1().
 		IPs(r.APINetNamespace).


### PR DESCRIPTION
during functionality review on my side I came across some irregularities.

This PR does not change any functionality, it merely harmonizes the following points across apinetlet controllers:
- import ordering
- func definition layout
- log output capitalization