### PR TITLE
Add `hostname` field to `NetworkInterface`

### DIFF
--- a/api/core/v1alpha1/networkinterface_types.go
+++ b/api/core/v1alpha1/networkinterface_types.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// NetworkInterfaceSpec defines the desired state of NetworkInterface.
 type NetworkInterfaceSpec struct {
 	// NodeRef is the node the network interface is hosted on.
 	NodeRef corev1.LocalObjectReference `json:"nodeRef"`
@@ -26,6 +27,9 @@ type NetworkInterfaceSpec struct {
 	// NATs specify the NAT of the network interface IP family.
 	// Can only be set if there is no matching IP family in PublicIPs.
 	NATs []NetworkInterfaceNAT `json:"natGateways,omitempty"`
+
+	// Hostname is the hostname which should be announced by the network interface.
+	Hostname string `json:"hostname,omitempty"`
 
 	// PublicIPs are the public IPs the network interface should have.
 	// +optional

--- a/client-go/applyconfigurations/core/v1alpha1/networkinterfacespec.go
+++ b/client-go/applyconfigurations/core/v1alpha1/networkinterfacespec.go
@@ -18,6 +18,7 @@ type NetworkInterfaceSpecApplyConfiguration struct {
 	IPs        []net.IP                                     `json:"ips,omitempty"`
 	Prefixes   []net.IPPrefix                               `json:"prefixes,omitempty"`
 	NATs       []NetworkInterfaceNATApplyConfiguration      `json:"natGateways,omitempty"`
+	Hostname   *string                                      `json:"hostname,omitempty"`
 	PublicIPs  []NetworkInterfacePublicIPApplyConfiguration `json:"publicIPs,omitempty"`
 }
 
@@ -73,6 +74,14 @@ func (b *NetworkInterfaceSpecApplyConfiguration) WithNATs(values ...*NetworkInte
 		}
 		b.NATs = append(b.NATs, *values[i])
 	}
+	return b
+}
+
+// WithHostname sets the Hostname field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Hostname field is set to the value of the last call.
+func (b *NetworkInterfaceSpecApplyConfiguration) WithHostname(value string) *NetworkInterfaceSpecApplyConfiguration {
+	b.Hostname = &value
 	return b
 }
 

--- a/client-go/applyconfigurations/internal/internal.go
+++ b/client-go/applyconfigurations/internal/internal.go
@@ -729,6 +729,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.ironcore-dev.ironcore-net.api.core.v1alpha1.NetworkInterfaceSpec
   map:
     fields:
+    - name: hostname
+      type:
+        scalar: string
     - name: ips
       type:
         list:

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -2668,7 +2668,8 @@ func schema_ironcore_net_api_core_v1alpha1_NetworkInterfaceSpec(ref common.Refer
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "NetworkInterfaceSpec defines the desired state of NetworkInterface.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"nodeRef": {
 						SchemaProps: spec.SchemaProps{
@@ -2722,6 +2723,13 @@ func schema_ironcore_net_api_core_v1alpha1_NetworkInterfaceSpec(ref common.Refer
 									},
 								},
 							},
+						},
+					},
+					"hostname": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Hostname is the hostname which should be announced by the network interface.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"publicIPs": {

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1331,6 +1331,17 @@ Can only be set if there is no matching IP family in PublicIPs.</p>
 </tr>
 <tr>
 <td>
+<code>hostname</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Hostname is the hostname which should be announced by the network interface.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>publicIPs</code><br/>
 <em>
 <a href="#core.apinet.ironcore.dev/v1alpha1.NetworkInterfacePublicIP">
@@ -3525,6 +3536,7 @@ github.com/ironcore-dev/ironcore-net/apimachinery/api/net.IP
 (<em>Appears on:</em><a href="#core.apinet.ironcore.dev/v1alpha1.NetworkInterface">NetworkInterface</a>)
 </p>
 <div>
+<p>NetworkInterfaceSpec defines the desired state of NetworkInterface.</p>
 </div>
 <table>
 <thead>
@@ -3598,6 +3610,17 @@ Kubernetes core/v1.LocalObjectReference
 <td>
 <p>NATs specify the NAT of the network interface IP family.
 Can only be set if there is no matching IP family in PublicIPs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hostname</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Hostname is the hostname which should be announced by the network interface.</p>
 </td>
 </tr>
 <tr>

--- a/gen/swagger.json
+++ b/gen/swagger.json
@@ -63520,12 +63520,17 @@
 			}
 		},
 		"com.github.ironcore-dev.ironcore-net.api.core.v1alpha1.NetworkInterfaceSpec": {
+			"description": "NetworkInterfaceSpec defines the desired state of NetworkInterface.",
 			"type": "object",
 			"required": [
 				"nodeRef",
 				"networkRef"
 			],
 			"properties": {
+				"hostname": {
+					"description": "Hostname is the hostname which should be announced by the network interface.",
+					"type": "string"
+				},
 				"ips": {
 					"description": "IPs are the internal IPs of the network interface.",
 					"type": "array",

--- a/gen/v3/apis__core.apinet.ironcore.dev__v1alpha1_openapi.json
+++ b/gen/v3/apis__core.apinet.ironcore.dev__v1alpha1_openapi.json
@@ -23117,12 +23117,17 @@
 				}
 			},
 			"com.github.ironcore-dev.ironcore-net.api.core.v1alpha1.NetworkInterfaceSpec": {
+				"description": "NetworkInterfaceSpec defines the desired state of NetworkInterface.",
 				"type": "object",
 				"required": [
 					"nodeRef",
 					"networkRef"
 				],
 				"properties": {
+					"hostname": {
+						"description": "Hostname is the hostname which should be announced by the network interface.",
+						"type": "string"
+					},
 					"ips": {
 						"description": "IPs are the internal IPs of the network interface.",
 						"type": "array",

--- a/internal/apis/core/networkinterface_types.go
+++ b/internal/apis/core/networkinterface_types.go
@@ -27,6 +27,9 @@ type NetworkInterfaceSpec struct {
 	// Can only be set if there is no matching IP family in PublicIPs.
 	NATs []NetworkInterfaceNAT
 
+	// Hostname is the hostname which should be announced by the network interface.
+	Hostname string
+
 	// PublicIPs are the public IPs the network interface should have.
 	// +optional
 	// +patchMergeKey=name

--- a/internal/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2337,6 +2337,7 @@ func autoConvert_v1alpha1_NetworkInterfaceSpec_To_core_NetworkInterfaceSpec(in *
 	out.IPs = *(*[]net.IP)(unsafe.Pointer(&in.IPs))
 	out.Prefixes = *(*[]net.IPPrefix)(unsafe.Pointer(&in.Prefixes))
 	out.NATs = *(*[]core.NetworkInterfaceNAT)(unsafe.Pointer(&in.NATs))
+	out.Hostname = in.Hostname
 	out.PublicIPs = *(*[]core.NetworkInterfacePublicIP)(unsafe.Pointer(&in.PublicIPs))
 	return nil
 }
@@ -2352,6 +2353,7 @@ func autoConvert_core_NetworkInterfaceSpec_To_v1alpha1_NetworkInterfaceSpec(in *
 	out.IPs = *(*[]net.IP)(unsafe.Pointer(&in.IPs))
 	out.Prefixes = *(*[]net.IPPrefix)(unsafe.Pointer(&in.Prefixes))
 	out.NATs = *(*[]corev1alpha1.NetworkInterfaceNAT)(unsafe.Pointer(&in.NATs))
+	out.Hostname = in.Hostname
 	out.PublicIPs = *(*[]corev1alpha1.NetworkInterfacePublicIP)(unsafe.Pointer(&in.PublicIPs))
 	return nil
 }

--- a/internal/apis/core/validation/networkinterface.go
+++ b/internal/apis/core/validation/networkinterface.go
@@ -26,6 +26,12 @@ func ValidateNetworkInterface(networkInterface *core.NetworkInterface) field.Err
 func ValidateNetworkInterfaceSpec(spec *core.NetworkInterfaceSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
+	if hostname := spec.Hostname; hostname != "" {
+		for _, msg := range validation.NameIsDNSLabel(hostname, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("hostname"), hostname, msg))
+		}
+	}
+
 	if spec.NodeRef.Name == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("nodeRef", "name"), "must specify target node"))
 	}
@@ -81,6 +87,7 @@ func ValidateNetworkInterfaceSpecUpdate(newSpec, oldSpec *core.NetworkInterfaceS
 
 	allErrs = append(allErrs, validation.ValidateImmutableField(newSpec.NetworkRef, oldSpec.NetworkRef, fldPath.Child("networkRef"))...)
 	allErrs = append(allErrs, validation.ValidateImmutableField(newSpec.NodeRef, oldSpec.NodeRef, fldPath.Child("nodeRef"))...)
+	allErrs = append(allErrs, validation.ValidateImmutableField(newSpec.Hostname, oldSpec.Hostname, fldPath.Child("hostname"))...)
 	if !slices.Equal(newSpec.IPs, oldSpec.IPs) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ips"), newSpec.IPs, validation.FieldImmutableErrorMsg))
 	}

--- a/internal/apis/core/validation/networkinterface_test.go
+++ b/internal/apis/core/validation/networkinterface_test.go
@@ -30,5 +30,28 @@ var _ = Describe("NetworkInterface", func() {
 				"Detail": Equal(apivalidation.FieldImmutableErrorMsg),
 			}))),
 		),
+		Entry("hostname update",
+			&core.NetworkInterfaceSpec{Hostname: "foo"},
+			&core.NetworkInterfaceSpec{Hostname: "bar"},
+			ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("spec.hostname"),
+				"Detail": Equal(apivalidation.FieldImmutableErrorMsg),
+			}))),
+		),
+	)
+
+	DescribeTable("ValidateNetworkInterface",
+		func(spec *core.NetworkInterfaceSpec, match types.GomegaMatcher) {
+			allErrs := validation.ValidateNetworkInterfaceSpec(spec, field.NewPath("spec"))
+			Expect(allErrs).To(match)
+		},
+		Entry("invalid hostname",
+			&core.NetworkInterfaceSpec{Hostname: "hostname*"},
+			ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("spec.hostname"),
+			}))),
+		),
 	)
 })

--- a/metalnetlet/controllers/networkinterface_controller.go
+++ b/metalnetlet/controllers/networkinterface_controller.go
@@ -526,7 +526,7 @@ func (r *NetworkInterfaceReconciler) applyMetalnetNic(ctx context.Context, log l
 			NAT:                 workaroundMetalnetNoIPv6NATDetailsToNATDetailsPointer(natIPs),
 			NodeName:            &metalnetNodeName,
 			FirewallRules:       npRules,
-			// Hostname goes here (from ironcore-net nic to metalnet nic)
+			Hostname:            &nic.Spec.Hostname,
 		},
 	}
 	log.V(1).Info("Applying metalnet network interface")

--- a/metalnetlet/controllers/networkinterface_controller.go
+++ b/metalnetlet/controllers/networkinterface_controller.go
@@ -526,6 +526,7 @@ func (r *NetworkInterfaceReconciler) applyMetalnetNic(ctx context.Context, log l
 			NAT:                 workaroundMetalnetNoIPv6NATDetailsToNATDetailsPointer(natIPs),
 			NodeName:            &metalnetNodeName,
 			FirewallRules:       npRules,
+			// Hostname goes here (from ironcore-net nic to metalnet nic)
 		},
 	}
 	log.V(1).Info("Applying metalnet network interface")

--- a/metalnetlet/controllers/networkinterface_controller_test.go
+++ b/metalnetlet/controllers/networkinterface_controller_test.go
@@ -625,7 +625,7 @@ var _ = Describe("NetworkInterfaceController", func() {
 			HaveField("Spec.IPFamilies", ConsistOf(corev1.IPv4Protocol)),
 			HaveField("Spec.IPs", ConsistOf(metalnetv1alpha1.MustParseIP("10.0.0.1"))),
 			HaveField("Spec.NodeName", Equal(&metalnetNode.Name)),
-			//HaveField("Spec.Hostname", Equal("foo")),
+			HaveField("Spec.Hostname", Equal(&nic.Spec.Hostname)),
 		))
 
 		By("updating the metalnet network interface's status")

--- a/metalnetlet/controllers/networkinterface_controller_test.go
+++ b/metalnetlet/controllers/networkinterface_controller_test.go
@@ -604,6 +604,7 @@ var _ = Describe("NetworkInterfaceController", func() {
 				IPs: []net.IP{
 					net.MustParseIP("10.0.0.1"),
 				},
+				Hostname: "foo",
 			},
 		}
 		Expect(k8sClient.Create(ctx, nic)).To(Succeed())
@@ -624,6 +625,7 @@ var _ = Describe("NetworkInterfaceController", func() {
 			HaveField("Spec.IPFamilies", ConsistOf(corev1.IPv4Protocol)),
 			HaveField("Spec.IPs", ConsistOf(metalnetv1alpha1.MustParseIP("10.0.0.1"))),
 			HaveField("Spec.NodeName", Equal(&metalnetNode.Name)),
+			//HaveField("Spec.Hostname", Equal("foo")),
 		))
 
 		By("updating the metalnet network interface's status")


### PR DESCRIPTION
# Proposed Changes

- Extend the `NetworkInterface` type with optional field `hostname`
- Propagate `hostName` to the corresponding `NetworkInterface` type in the metalnet
- Update test

Fixes #399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Network interfaces now support specifying a hostname that will be announced. The hostname field undergoes DNS label validation to ensure compliance and is immutable after initial configuration, preventing accidental modifications to network interface identities.

* **Documentation**
  * Updated API reference documentation to include the new hostname configuration option for network interfaces with validation requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->