### PR TITLE
Allow IP allocation from multiple `public-prefixes` of same IPFamily

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=

--- a/internal/app/app_suite_test.go
+++ b/internal/app/app_suite_test.go
@@ -91,7 +91,7 @@ var _ = BeforeSuite(func() {
 		Port:         testEnvExt.APIServiceInstallOptions.LocalServingPort,
 		CertDir:      testEnvExt.APIServiceInstallOptions.LocalServingCertDir,
 		Args: apiserver.ProcessArgs{
-			"public-prefix": []string{"10.0.0.0/24"},
+			"public-prefix": []string{"10.0.0.0/29", "10.0.1.0/29"},
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- Allow`publicIP` address allocation from multiple `public-prefixes` of same `IPFamily`
- Validate `PublicIP` allocation from multiple `public-prefixes` of same `IPFamily` with testcases


Fixes #409 