### PR TITLE
Retain labels of apinet nic before setting claimer labels

### DIFF
--- a/apinetlet/controllers/networkinterface_controller.go
+++ b/apinetlet/controllers/networkinterface_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/exp/slices"
@@ -224,7 +225,8 @@ func (s *apiNetNetworkInterfaceClaimStrategy) ClaimState(claimer client.Object, 
 func (s *apiNetNetworkInterfaceClaimStrategy) Adopt(ctx context.Context, claimer client.Object, obj client.Object) error {
 	apiNetNic := obj.(*apinetv1alpha1.NetworkInterface)
 	base := apiNetNic.DeepCopy()
-	combinedLabels := make(map[string]string)
+	combinedLabels := make(map[string]string, len(apiNetNic.GetLabels())+len(claimer.GetLabels()))
+	maps.Copy(combinedLabels, apiNetNic.GetLabels())
 	if claimerLabels := claimer.GetLabels(); claimerLabels != nil {
 		for key, value := range claimerLabels {
 			combinedLabels[key] = value

--- a/apinetlet/controllers/networkinterface_controller_test.go
+++ b/apinetlet/controllers/networkinterface_controller_test.go
@@ -50,6 +50,9 @@ var _ = Describe("NetworkInterfaceController", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    apiNetNs.Name,
 				GenerateName: "apinet-nic-",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
 			},
 			Spec: apinetv1alpha1.NetworkInterfaceSpec{
 				NetworkRef: corev1.LocalObjectReference{Name: apiNetNetwork.Name},
@@ -84,7 +87,10 @@ var _ = Describe("NetworkInterfaceController", func() {
 
 		By("waiting for the APINet network interface to be claimed")
 		Eventually(Object(apiNetNic)).Should(SatisfyAll(
-			HaveField("Labels", HaveKeyWithValue("app", "test")),
+			HaveField("Labels", HaveKeysWithValues(map[string]string{
+				"app": "test",
+				"foo": "bar",
+			})),
 			HaveField("Spec.PublicIPs", ConsistOf(HaveField("IP", net.IP{Addr: publicIP.Addr}))),
 			WithTransform(func(apiNetNic *apinetv1alpha1.NetworkInterface) *apinetletclient.SourceObjectData {
 				return apinetletclient.SourceObjectDataFromObject(


### PR DESCRIPTION
# Proposed Changes

- Retain networkinterface labels before setting claimer labels

Fixes #417 