### PR TITLE
Fix premature IP deletion

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -185,7 +185,7 @@ func main() {
 		APIReader:    mgr.GetAPIReader(),
 		AbsenceCache: lru.New(500),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "DaemonSet")
+		setupLog.Error(err, "unable to create controller", "controller", "IPAddressGC")
 		os.Exit(1)
 	}
 

--- a/internal/app/apiserver/apiserver.go
+++ b/internal/app/apiserver/apiserver.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/netip"
@@ -13,20 +14,29 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/openapi"
 	"k8s.io/component-base/compatibility"
 
+	"time"
+
 	"github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
 	informers "github.com/ironcore-dev/ironcore-net/client-go/informers/externalversions"
 	clientset "github.com/ironcore-dev/ironcore-net/client-go/ironcorenet/versioned"
 	"github.com/ironcore-dev/ironcore-net/internal/apiserver"
+	"github.com/ironcore-dev/ironcore-net/internal/registry/ipallocator"
 	netflag "github.com/ironcore-dev/ironcore-net/utils/flag"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 )
 
@@ -163,5 +173,151 @@ func (o *IronCoreNetServerOptions) Run(ctx context.Context) error {
 		return nil
 	})
 
+	// TODO: Remove this migration logic once all IPs have been migrated from OwnerReference to ephemeral label.
+	// This is a one-time migration: once all IPs carry the ephemeral label, this hook becomes a no-op.
+	// Check logs for "IP OwnerRef to ephemeral label migration: COMPLETE" to confirm migration is done.
+	// After migration is complete, also remove the legacy OwnerReference check in ipallocator.Release().
+	server.GenericAPIServer.AddPostStartHookOrDie("migrate-ip-ownerref-to-ephemeral-label", func(hookContext genericapiserver.PostStartHookContext) error {
+		ironcoreNetClient, err := clientset.NewForConfig(config.GenericConfig.LoopbackClientConfig)
+		if err != nil {
+			klog.ErrorS(err, "Failed to create client for IP OwnerRef migration")
+			return nil
+		}
+
+		const ipListPageSize = 500
+		var allIPs []v1alpha1.IP
+		continueToken := ""
+
+		for {
+			listOptions := metav1.ListOptions{
+				Limit:    ipListPageSize,
+				Continue: continueToken,
+			}
+
+			ipList, err := ironcoreNetClient.CoreV1alpha1().IPs("").List(hookContext, listOptions)
+			if err != nil {
+				klog.ErrorS(err, "Failed to list IPs for OwnerRef migration")
+				return nil
+			}
+
+			allIPs = append(allIPs, ipList.Items...)
+
+			continueToken = ipList.Continue
+			if continueToken == "" {
+				break
+			}
+		}
+
+		ipList := &v1alpha1.IPList{
+			Items: allIPs,
+		}
+
+		var migrated, skipped, failed int
+		for i := range ipList.Items {
+			select {
+			case <-hookContext.Done():
+				klog.InfoS("IP OwnerRef to ephemeral label migration: INTERRUPTED - Migration interrupted by server shutdown",
+					"migrated", migrated, "skipped", skipped, "failed", failed)
+				return nil
+			default:
+			}
+
+			ip := &ipList.Items[i]
+
+			if ip.Labels[ipallocator.IPEphemeralLabel] == "true" {
+				skipped++
+				continue
+			}
+
+			if metav1.GetControllerOf(ip) == nil {
+				skipped++
+				continue
+			}
+
+			if err := migrateIP(hookContext, ironcoreNetClient, ip); err != nil {
+				klog.ErrorS(err, "Failed to migrate IP from OwnerRef to ephemeral label", "ip", klog.KObj(ip))
+				failed++
+				continue
+			}
+			migrated++
+		}
+
+		if migrated == 0 && failed == 0 {
+			klog.InfoS("IP OwnerRef to ephemeral label migration: COMPLETE - No IPs with OwnerReference found, migration not needed",
+				"totalIPs", len(ipList.Items))
+			return nil
+		}
+
+		if failed == 0 && migrated > 0 {
+			klog.InfoS("IP OwnerRef to ephemeral label migration: COMPLETE - All IPs successfully migrated",
+				"migrated", migrated, "skipped", skipped, "total", len(ipList.Items))
+		} else if failed > 0 {
+			klog.InfoS("IP OwnerRef to ephemeral label migration: PARTIAL - Some IPs failed to migrate, will retry on next startup",
+				"migrated", migrated, "failed", failed, "skipped", skipped, "total", len(ipList.Items))
+		}
+		return nil
+	})
+
 	return server.GenericAPIServer.PrepareRun().RunWithContext(ctx)
+}
+
+// TODO: Remove this migration logic once all IPs have been migrated from OwnerReference to ephemeral label.
+// migrateIP migrates a single IP from OwnerReference-based detection to label-based detection.
+// It uses retry logic with exponential backoff to handle transient API errors.
+func migrateIP(ctx context.Context, ironcoreNetClient clientset.Interface, ip *v1alpha1.IP) error {
+	patchObj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]string{
+				ipallocator.IPEphemeralLabel: "true",
+			},
+			"ownerReferences": nil,
+		},
+	}
+
+	patch, err := json.Marshal(patchObj)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+
+	retryBackoff := wait.Backoff{
+		Steps:    3,
+		Duration: 10 * time.Millisecond,
+		Factor:   2.0,
+		Jitter:   0.1,
+	}
+	return retry.OnError(
+		retryBackoff,
+		func(err error) bool {
+			return apierrors.IsServerTimeout(err) ||
+				apierrors.IsTimeout(err) ||
+				apierrors.IsTooManyRequests(err) ||
+				apierrors.IsInternalError(err) ||
+				apierrors.IsServiceUnavailable(err)
+		},
+		func() error {
+			patched, err := ironcoreNetClient.CoreV1alpha1().IPs(ip.Namespace).Patch(
+				ctx,
+				ip.Name,
+				types.MergePatchType,
+				patch,
+				metav1.PatchOptions{},
+			)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+
+			if patched.Labels[ipallocator.IPEphemeralLabel] != "true" {
+				return fmt.Errorf("patch succeeded but ephemeral label not found on IP %s", klog.KObj(patched))
+			}
+
+			if len(patched.OwnerReferences) != 0 {
+				return fmt.Errorf("failed to remove ownerReferences from IP %s: %d ownerReferences still present", klog.KObj(patched), len(patched.OwnerReferences))
+			}
+
+			return nil
+		},
+	)
 }

--- a/internal/registry/ipallocator/ipallocator.go
+++ b/internal/registry/ipallocator/ipallocator.go
@@ -240,7 +240,10 @@ func (a *Allocator) release(namespace string, addr netip.Addr, dryRun bool) erro
 		return nil
 	}
 
-	if ip.Labels[IPEphemeralLabel] == "true" {
+	// TODO: Remove the legacy OwnerReference check (|| metav1.GetControllerOf(ip) != nil) once migration is complete.
+	// Check apiserver logs for "IP OwnerRef to ephemeral label migration: COMPLETE" to confirm migration is done.
+	// Treat IP as ephemeral if it has the ephemeral label or a legacy controller OwnerReference
+	if ip.Labels[IPEphemeralLabel] == "true" || metav1.GetControllerOf(ip) != nil {
 		err := a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{})
 		if err == nil || apierrors.IsNotFound(err) {
 			return nil

--- a/internal/registry/ipallocator/ipallocator.go
+++ b/internal/registry/ipallocator/ipallocator.go
@@ -15,14 +15,12 @@ import (
 	v1alpha1informers "github.com/ironcore-dev/ironcore-net/client-go/informers/externalversions/core/v1alpha1"
 	v1alpha1client "github.com/ironcore-dev/ironcore-net/client-go/ironcorenet/versioned/typed/core/v1alpha1"
 	v1alpha1listers "github.com/ironcore-dev/ironcore-net/client-go/listers/core/v1alpha1"
-	"github.com/ironcore-dev/ironcore/utils/generic"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -34,6 +32,8 @@ var (
 	ErrAllocated = errors.New("provided IP is already allocated")
 	ErrNotFound  = errors.New("provided IP was not found")
 )
+
+const IPEphemeralLabel = "core.apinet.ironcore.dev/ephemeral"
 
 type Allocator struct {
 	prefixes []netip.Prefix
@@ -206,15 +206,8 @@ func (a *Allocator) createEphemeralIP(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    namespace,
 			GenerateName: claimRef.Name + "-",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         (schema.GroupVersion{Group: claimRef.Group, Version: version}).String(),
-					Kind:               kind,
-					Name:               claimRef.Name,
-					UID:                claimRef.UID,
-					Controller:         generic.Pointer(true),
-					BlockOwnerDeletion: generic.Pointer(true),
-				},
+			Labels: map[string]string{
+				IPEphemeralLabel: "true",
 			},
 		},
 		Spec: v1alpha1.IPSpec{
@@ -247,11 +240,9 @@ func (a *Allocator) release(namespace string, addr netip.Addr, dryRun bool) erro
 		return nil
 	}
 
-	// If the IP is controlled, we assume it to be ephemeral.
-	// TODO: check on something more robust than just an owner reference.
-	if metav1.GetControllerOf(ip) != nil {
+	if ip.Labels[IPEphemeralLabel] == "true" {
 		err := a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{})
-		if err == nil {
+		if err == nil || apierrors.IsNotFound(err) {
 			return nil
 		}
 		klog.ErrorS(err, "error deleting IP", "ip", klog.KObj(ip))


### PR DESCRIPTION
# Summary

This PR fixes IP collision issues caused by GC propagation delay by replacing OwnerReference-based ephemeral IP detection with label-based detection. It includes an automatic migration hook to transition existing allocated IPs from OwnerReference to ephemeral labels.

**Key Changes**:
- IPs created without OwnerReference (prevents GC from prematurely deleting IPs)
- Label-based ephemeral IP detection (`core.apinet.ironcore.dev/ephemeral=true`)
- Automatic migration hook to transition existing IPs from OwnerRef to ephemeral labels
- Tested and passing with both large and small IP pools

Fixes #457

---

## Problem Summary

### Issue: IP Deletion and IP Collision

When creating multiple NATGateways or LoadBalancers:
- **IP Deletion**: IP/IPAddress objects are deleted prematurely, leaving stale IPs in `spec.ips` fields
- **IP Collision**: Multiple resources are assigned the same IP address (consequence of IP deletion)

### Root Cause: GC Propagation Delay

A **GC propagation delay** issue occurs when:
1. Owner (LoadBalancer/NATGateway) is committed to etcd
2. IP object is created with OwnerReference immediately after
3. GC checks OwnerReference but can't find owner in its watch cache (propagation delay)
4. GC deletes IP object as orphan → IP released to pool → re-allocated → collision

**The propagation delay** creates a window where the owner exists in etcd, but GC's watch cache hasn't updated yet, so GC thinks the owner doesn't exist and prematurely deletes the IP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an incorrect controller name shown in error logs during IP garbage-collection setup.

* **Refactor**
  * Switched ephemeral IP tracking from owner-reference to a label-based marker and updated allocation/release logic to recognize either the label or existing ownership for identifying ephemeral addresses.

* **Chores**
  * Added a one-time startup migration to label existing ephemeral IPs for seamless transition; includes retries and progress logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->