### PR TITLE
Fix double IP allocation by adding optimistic locking and claimRef identity guard to ipallocator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ vendor
 *.swp
 *.swo
 *~
+dev/

--- a/api/core/v1alpha1/well_known_labels.go
+++ b/api/core/v1alpha1/well_known_labels.go
@@ -12,4 +12,6 @@ const (
 	TopologyLabelPrefix    = "topology.core.apinet.ironcore.dev/"
 	TopologyPartitionLabel = TopologyLabelPrefix + "partition"
 	TopologyZoneLabel      = TopologyLabelPrefix + "zone"
+
+	IPEphemeralLabel = "apinet.ironcore.dev/ip-ephemeral"
 )

--- a/internal/app/apiserver/apiserver.go
+++ b/internal/app/apiserver/apiserver.go
@@ -177,21 +177,27 @@ func (o *IronCoreNetServerOptions) Run(ctx context.Context) error {
 			return nil
 		}
 
-		migrateEphemeralIPOwnerReferences(ipClient)
+		hookCtx, cancel := context.WithCancel(context.Background())
+		go func() {
+			<-hookContext.Done()
+			cancel()
+		}()
+
+		migrateEphemeralIPOwnerReferences(hookCtx, ipClient)
 		return nil
 	})
 
 	return server.GenericAPIServer.PrepareRun().RunWithContext(ctx)
 }
 
-func migrateEphemeralIPOwnerReferences(ipClient v1alpha1client.CoreV1alpha1Interface) {
+func migrateEphemeralIPOwnerReferences(ctx context.Context, ipClient v1alpha1client.CoreV1alpha1Interface) {
 	var (
 		continueToken string
 		migrated      int
 	)
 
 	for {
-		ipList, err := ipClient.IPs("").List(context.Background(), metav1.ListOptions{
+		ipList, err := ipClient.IPs("").List(ctx, metav1.ListOptions{
 			Limit:    500,
 			Continue: continueToken,
 		})
@@ -220,7 +226,7 @@ func migrateEphemeralIPOwnerReferences(ipClient v1alpha1client.CoreV1alpha1Inter
 				continue
 			}
 
-			_, err = ipClient.IPs(ip.Namespace).Patch(context.Background(), ip.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+			_, err = ipClient.IPs(ip.Namespace).Patch(ctx, ip.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
 			if err != nil {
 				slog.Error("Failed to migrate IP", "ip", ip.Name, "namespace", ip.Namespace, "error", err)
 				continue

--- a/internal/app/apiserver/apiserver.go
+++ b/internal/app/apiserver/apiserver.go
@@ -5,7 +5,9 @@ package apiserver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/netip"
 
@@ -16,12 +18,15 @@ import (
 	"github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
 	informers "github.com/ironcore-dev/ironcore-net/client-go/informers/externalversions"
 	clientset "github.com/ironcore-dev/ironcore-net/client-go/ironcorenet/versioned"
+	v1alpha1client "github.com/ironcore-dev/ironcore-net/client-go/ironcorenet/versioned/typed/core/v1alpha1"
 	"github.com/ironcore-dev/ironcore-net/internal/apiserver"
 	netflag "github.com/ironcore-dev/ironcore-net/utils/flag"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -163,5 +168,73 @@ func (o *IronCoreNetServerOptions) Run(ctx context.Context) error {
 		return nil
 	})
 
+	// TODO: This is temporary migration code to strip OwnerReferences from legacy ephemeral IPs.
+	// Remove this hook once all clusters have been migrated.
+	server.GenericAPIServer.AddPostStartHookOrDie("migrate-ephemeral-ip-owner-references", func(hookContext genericapiserver.PostStartHookContext) error {
+		ipClient, err := v1alpha1client.NewForConfig(hookContext.LoopbackClientConfig)
+		if err != nil {
+			slog.Error("Failed to create client for IP migration", "error", err)
+			return nil
+		}
+
+		migrateEphemeralIPOwnerReferences(ipClient)
+		return nil
+	})
+
 	return server.GenericAPIServer.PrepareRun().RunWithContext(ctx)
+}
+
+func migrateEphemeralIPOwnerReferences(ipClient v1alpha1client.CoreV1alpha1Interface) {
+	var (
+		continueToken string
+		migrated      int
+	)
+
+	for {
+		ipList, err := ipClient.IPs("").List(context.Background(), metav1.ListOptions{
+			Limit:    500,
+			Continue: continueToken,
+		})
+		if err != nil {
+			slog.Error("Failed to list IPs for migration", "error", err)
+			return
+		}
+
+		for i := range ipList.Items {
+			ip := &ipList.Items[i]
+			if metav1.GetControllerOf(ip) == nil {
+				continue
+			}
+
+			patch := map[string]any{
+				"metadata": map[string]any{
+					"ownerReferences": []any{},
+					"labels": map[string]string{
+						v1alpha1.IPEphemeralLabel: "true",
+					},
+				},
+			}
+			patchData, err := json.Marshal(patch)
+			if err != nil {
+				slog.Error("Failed to marshal migration patch", "ip", ip.Name, "namespace", ip.Namespace, "error", err)
+				continue
+			}
+
+			_, err = ipClient.IPs(ip.Namespace).Patch(context.Background(), ip.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+			if err != nil {
+				slog.Error("Failed to migrate IP", "ip", ip.Name, "namespace", ip.Namespace, "error", err)
+				continue
+			}
+			migrated++
+		}
+
+		continueToken = ipList.Continue
+		if continueToken == "" {
+			break
+		}
+	}
+
+	if migrated > 0 {
+		slog.Info("Migrated ephemeral IPs: stripped OwnerReferences and ensured label", "count", migrated)
+	}
 }

--- a/internal/registry/ipallocator/allocators.go
+++ b/internal/registry/ipallocator/allocators.go
@@ -58,7 +58,6 @@ type Allocators struct {
 	allocByFamily map[corev1.IPFamily]Interface
 
 	gv       schema.GroupVersion
-	kind     string
 	resource string
 
 	accessorFor func(obj runtime.Object) (Accessor, error)
@@ -67,13 +66,12 @@ type Allocators struct {
 func NewAllocators(
 	allocByIPFamily map[corev1.IPFamily]Interface,
 	gv schema.GroupVersion,
-	kind, resource string,
+	resource string,
 	accessorFor func(obj runtime.Object) (Accessor, error),
 ) *Allocators {
 	return &Allocators{
 		allocByFamily: allocByIPFamily,
 		gv:            gv,
-		kind:          kind,
 		resource:      resource,
 		accessorFor:   accessorFor,
 	}
@@ -143,7 +141,7 @@ func (a *Allocators) allocateIPs(allocByFamily map[corev1.IPFamily]Interface, ac
 				return allocated, err
 			}
 		} else {
-			newAddr, err := alloc.AllocateNext(acc.GetNamespace(), claimRef, a.gv.Version, a.kind)
+			newAddr, err := alloc.AllocateNext(acc.GetNamespace(), claimRef)
 			if err != nil {
 				return allocated, err
 			}

--- a/internal/registry/ipallocator/allocators.go
+++ b/internal/registry/ipallocator/allocators.go
@@ -100,14 +100,23 @@ func (a *Allocators) allocatorsForRequestIterator(it func(yield func(Request) bo
 	return allocs, err
 }
 
-func (a *Allocators) releaseIPs(allocByIPFamily map[corev1.IPFamily]Interface, namespace string, ips []netip.Addr) ([]netip.Addr, error) {
+func (a *Allocators) claimRefFor(acc Accessor) v1alpha1.IPClaimRef {
+	return v1alpha1.IPClaimRef{
+		Group:    a.gv.Group,
+		Resource: a.resource,
+		Name:     acc.GetName(),
+		UID:      acc.GetUID(),
+	}
+}
+
+func (a *Allocators) releaseIPs(allocByIPFamily map[corev1.IPFamily]Interface, namespace string, ips []netip.Addr, claimRef v1alpha1.IPClaimRef) ([]netip.Addr, error) {
 	var (
 		released []netip.Addr
 		errs     []error
 	)
 	for _, ip := range ips {
 		alloc := allocByIPFamily[core.IPFamilyForAddr(ip)]
-		if err := alloc.Release(namespace, ip); err != nil {
+		if err := alloc.Release(namespace, ip, claimRef); err != nil {
 			errs = append(errs, err)
 			continue
 		}
@@ -182,7 +191,7 @@ func (a *Allocators) AllocateCreate(obj runtime.Object, dryRun bool) (Transactio
 				return
 			}
 
-			actuallyReleased, err := a.releaseIPs(allocs, acc.GetNamespace(), allocated)
+			actuallyReleased, err := a.releaseIPs(allocs, acc.GetNamespace(), allocated, a.claimRefFor(acc))
 			if err != nil {
 				klog.ErrorS(err, "Error releasing IPs",
 					"shouldRelease", allocated,
@@ -247,7 +256,7 @@ func (a *Allocators) AllocateUpdate(obj, oldObj runtime.Object, dryRun bool) (Tr
 			}
 
 			toRelease := toReleaseSet.UnsortedList()
-			if actuallyReleased, err := a.releaseIPs(allocs, acc.GetNamespace(), toRelease); err != nil {
+			if actuallyReleased, err := a.releaseIPs(allocs, acc.GetNamespace(), toRelease, a.claimRefFor(oldAcc)); err != nil {
 				klog.ErrorS(err, "Error releasing IPs",
 					"shouldRelease", toRelease,
 					"released", actuallyReleased,
@@ -259,7 +268,7 @@ func (a *Allocators) AllocateUpdate(obj, oldObj runtime.Object, dryRun bool) (Tr
 				return
 			}
 
-			if actuallyReleased, err := a.releaseIPs(allocs, acc.GetNamespace(), toReleaseSet.UnsortedList()); err != nil {
+			if actuallyReleased, err := a.releaseIPs(allocs, acc.GetNamespace(), toReleaseSet.UnsortedList(), a.claimRefFor(acc)); err != nil {
 				klog.ErrorS(err, "Error releasing IPs",
 					"shouldRelease", allocated,
 					"released", actuallyReleased,
@@ -288,7 +297,7 @@ func (a *Allocators) Release(obj runtime.Object, dryRun bool) {
 	}
 
 	allocated := utilslices.Map(reqs, func(r Request) netip.Addr { return r.Addr })
-	actuallyReleased, err := a.releaseIPs(allocs, acc.GetNamespace(), allocated)
+	actuallyReleased, err := a.releaseIPs(allocs, acc.GetNamespace(), allocated, a.claimRefFor(acc))
 	if err != nil {
 		klog.ErrorS(err, "Error releasing IPs",
 			"shouldRelease", allocated,

--- a/internal/registry/ipallocator/ipallocator.go
+++ b/internal/registry/ipallocator/ipallocator.go
@@ -228,9 +228,13 @@ func (a *Allocator) release(namespace string, addr netip.Addr, claimRef v1alpha1
 
 		// If the IP is labeled as ephemeral, delete it.
 		if ip.Labels[v1alpha1.IPEphemeralLabel] == "true" {
-			return a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{
+			err := a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{ResourceVersion: &ip.ResourceVersion},
 			})
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
 		}
 
 		return a.releaseIP(ip)

--- a/internal/registry/ipallocator/ipallocator.go
+++ b/internal/registry/ipallocator/ipallocator.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utiltrace "k8s.io/utils/trace"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -131,32 +131,32 @@ func (a *Allocator) getIPFromClient(namespace string, addr netip.Addr) (*v1alpha
 }
 
 func (a *Allocator) claimIP(namespace string, claimRef v1alpha1.IPClaimRef, addr netip.Addr) error {
-	ip, err := a.getIPFromLister(namespace, addr)
-	if err != nil {
-		return err
-	}
-	if ip.Spec.ClaimRef != nil {
-		return ErrAllocated
-	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ip, err := a.getIPFromClient(namespace, addr)
+		if err != nil {
+			return err
+		}
+		if ip.Spec.ClaimRef != nil {
+			return ErrAllocated
+		}
 
-	base := ip.DeepCopy()
-	ip.Spec.ClaimRef = &claimRef
-	data, err := client.StrategicMergeFrom(base).Data(ip)
-	if err != nil {
-		return err
-	}
+		base := ip.DeepCopy()
+		ip.Spec.ClaimRef = &claimRef
+		patch := client.MergeFromWithOptions(base, &client.MergeFromWithOptimisticLock{})
+		data, err := patch.Data(ip)
+		if err != nil {
+			return err
+		}
 
-	_, err = a.client.IPs(namespace).Patch(context.Background(), ip.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
-	if err == nil {
-		return nil
-	}
-	if apierrors.IsNotFound(err) {
-		return ErrNotFound
-	}
-	if apierrors.IsConflict(err) {
-		return ErrAllocated
-	}
-	return err
+		_, err = a.client.IPs(namespace).Patch(context.Background(), ip.Name, patch.Type(), data, metav1.PatchOptions{})
+		if err == nil {
+			return nil
+		}
+		if apierrors.IsNotFound(err) {
+			return ErrNotFound
+		}
+		return err
+	})
 }
 
 func (a *Allocator) AllocateNext(
@@ -229,11 +229,11 @@ func (a *Allocator) createEphemeralIP(
 	return ip.Spec.IP.Addr, nil
 }
 
-func (a *Allocator) Release(namespace string, ip netip.Addr) error {
-	return a.release(namespace, ip, false)
+func (a *Allocator) Release(namespace string, ip netip.Addr, claimRef v1alpha1.IPClaimRef) error {
+	return a.release(namespace, ip, claimRef, false)
 }
 
-func (a *Allocator) release(namespace string, addr netip.Addr, dryRun bool) error {
+func (a *Allocator) release(namespace string, addr netip.Addr, claimRef v1alpha1.IPClaimRef, dryRun bool) error {
 	if !a.ipSynced() {
 		return fmt.Errorf("allocator not ready")
 	}
@@ -241,25 +241,27 @@ func (a *Allocator) release(namespace string, addr netip.Addr, dryRun bool) erro
 		return nil
 	}
 
-	ip, err := a.getIPFromClient(namespace, addr)
-	if err != nil {
-		klog.ErrorS(err, "error getting IP for address", "address", addr)
-		return nil
-	}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ip, err := a.getIPFromClient(namespace, addr)
+		if err != nil {
+			return err
+		}
 
-	// If the IP is controlled, we assume it to be ephemeral.
-	// TODO: check on something more robust than just an owner reference.
-	if metav1.GetControllerOf(ip) != nil {
-		err := a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{})
-		if err == nil {
+		// If the claim no longer belongs to the expected owner, the IP was
+		// reclaimed by another resource — nothing to release.
+		if ip.Spec.ClaimRef == nil || ip.Spec.ClaimRef.UID != claimRef.UID {
 			return nil
 		}
-		klog.ErrorS(err, "error deleting IP", "ip", klog.KObj(ip))
-		return nil
-	}
 
-	if err := a.releaseIP(ip); err != nil {
-		klog.ErrorS(err, "error releasing IP", "ip", klog.KObj(ip))
+		// If the IP is controlled, we assume it to be ephemeral.
+		if metav1.GetControllerOf(ip) != nil {
+			return a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{})
+		}
+
+		return a.releaseIP(ip)
+	})
+	if err != nil {
+		klog.ErrorS(err, "error releasing IP for address", "address", addr)
 	}
 	return nil
 }
@@ -267,11 +269,12 @@ func (a *Allocator) release(namespace string, addr netip.Addr, dryRun bool) erro
 func (a *Allocator) releaseIP(ip *v1alpha1.IP) error {
 	base := ip.DeepCopy()
 	ip.Spec.ClaimRef = nil
-	data, err := client.StrategicMergeFrom(base).Data(ip)
+	patch := client.MergeFromWithOptions(base, &client.MergeFromWithOptimisticLock{})
+	data, err := patch.Data(ip)
 	if err != nil {
 		return err
 	}
-	_, err = a.client.IPs(ip.Namespace).Patch(context.Background(), ip.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+	_, err = a.client.IPs(ip.Namespace).Patch(context.Background(), ip.Name, patch.Type(), data, metav1.PatchOptions{})
 	return err
 }
 
@@ -299,8 +302,8 @@ func (dry dryRunAllocator) AllocateNext(
 	return dry.real.allocateNext(namespace, claimRef, version, kind, true)
 }
 
-func (dry dryRunAllocator) Release(namespace string, ip netip.Addr) error {
-	return dry.real.release(namespace, ip, true)
+func (dry dryRunAllocator) Release(namespace string, ip netip.Addr, claimRef v1alpha1.IPClaimRef) error {
+	return dry.real.release(namespace, ip, claimRef, true)
 }
 
 func (dry dryRunAllocator) DryRun() Interface {
@@ -311,6 +314,6 @@ type Interface interface {
 	IPFamily() corev1.IPFamily
 	Allocate(namespace string, claimRef v1alpha1.IPClaimRef, ip netip.Addr) error
 	AllocateNext(namespace string, claimRef v1alpha1.IPClaimRef, version, kind string) (netip.Addr, error)
-	Release(namespace string, ip netip.Addr) error
+	Release(namespace string, ip netip.Addr, claimRef v1alpha1.IPClaimRef) error
 	DryRun() Interface
 }

--- a/internal/registry/ipallocator/ipallocator.go
+++ b/internal/registry/ipallocator/ipallocator.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog/v2"
 	utiltrace "k8s.io/utils/trace"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -241,9 +240,13 @@ func (a *Allocator) release(namespace string, addr netip.Addr, claimRef v1alpha1
 		return nil
 	}
 
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		ip, err := a.getIPFromClient(namespace, addr)
 		if err != nil {
+			// IP is already gone — nothing to release.
+			if err == ErrNotFound {
+				return nil
+			}
 			return err
 		}
 
@@ -255,15 +258,13 @@ func (a *Allocator) release(namespace string, addr netip.Addr, claimRef v1alpha1
 
 		// If the IP is controlled, we assume it to be ephemeral.
 		if metav1.GetControllerOf(ip) != nil {
-			return a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{})
+			return a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{ResourceVersion: &ip.ResourceVersion},
+			})
 		}
 
 		return a.releaseIP(ip)
 	})
-	if err != nil {
-		klog.ErrorS(err, "error releasing IP for address", "address", addr)
-	}
-	return nil
 }
 
 func (a *Allocator) releaseIP(ip *v1alpha1.IP) error {

--- a/internal/registry/ipallocator/ipallocator.go
+++ b/internal/registry/ipallocator/ipallocator.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"strings"
 	"time"
 
 	"github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
@@ -21,7 +20,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
@@ -95,22 +93,6 @@ func (a *Allocator) allocate(namespace string, claimRef v1alpha1.IPClaimRef, ip 
 	}
 
 	return a.claimIP(namespace, claimRef, ip)
-}
-
-func (a *Allocator) getIPFromLister(namespace string, addr netip.Addr) (*v1alpha1.IP, error) {
-	ips, err := a.ipLister.IPs(namespace).List(labels.SelectorFromSet(labels.Set{
-		v1alpha1.IPFamilyLabel: string(a.ipFamily),
-		v1alpha1.IPIPLabel:     strings.ReplaceAll(addr.String(), ":", "-"),
-	}))
-	if err != nil {
-		return nil, err
-	}
-	if n := len(ips); n == 0 {
-		return nil, ErrNotFound
-	} else if n > 1 {
-		return nil, fmt.Errorf("multiple IPs found for address %s", addr)
-	}
-	return ips[0], nil
 }
 
 func (a *Allocator) getIPFromClient(namespace string, addr netip.Addr) (*v1alpha1.IP, error) {

--- a/internal/registry/ipallocator/ipallocator.go
+++ b/internal/registry/ipallocator/ipallocator.go
@@ -14,13 +14,11 @@ import (
 	v1alpha1informers "github.com/ironcore-dev/ironcore-net/client-go/informers/externalversions/core/v1alpha1"
 	v1alpha1client "github.com/ironcore-dev/ironcore-net/client-go/ironcorenet/versioned/typed/core/v1alpha1"
 	v1alpha1listers "github.com/ironcore-dev/ironcore-net/client-go/listers/core/v1alpha1"
-	"github.com/ironcore-dev/ironcore/utils/generic"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	utiltrace "k8s.io/utils/trace"
@@ -143,15 +141,13 @@ func (a *Allocator) claimIP(namespace string, claimRef v1alpha1.IPClaimRef, addr
 func (a *Allocator) AllocateNext(
 	namespace string,
 	claimRef v1alpha1.IPClaimRef,
-	version, kind string,
 ) (netip.Addr, error) {
-	return a.allocateNext(namespace, claimRef, version, kind, false)
+	return a.allocateNext(namespace, claimRef, false)
 }
 
 func (a *Allocator) allocateNext(
 	namespace string,
 	claimRef v1alpha1.IPClaimRef,
-	version, kind string,
 	dryRun bool,
 ) (netip.Addr, error) {
 	if !a.ipSynced() {
@@ -166,7 +162,7 @@ func (a *Allocator) allocateNext(
 
 	// Try each prefix in order
 	for range a.prefixes {
-		ip, err := a.createEphemeralIP(namespace, claimRef, version, kind)
+		ip, err := a.createEphemeralIP(namespace, claimRef)
 		if err == nil {
 			return ip, nil
 		}
@@ -181,21 +177,13 @@ func (a *Allocator) allocateNext(
 func (a *Allocator) createEphemeralIP(
 	namespace string,
 	claimRef v1alpha1.IPClaimRef,
-	version, kind string,
 ) (netip.Addr, error) {
 	ip, err := a.client.IPs(namespace).Create(context.Background(), &v1alpha1.IP{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    namespace,
 			GenerateName: claimRef.Name + "-",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         (schema.GroupVersion{Group: claimRef.Group, Version: version}).String(),
-					Kind:               kind,
-					Name:               claimRef.Name,
-					UID:                claimRef.UID,
-					Controller:         generic.Pointer(true),
-					BlockOwnerDeletion: generic.Pointer(true),
-				},
+			Labels: map[string]string{
+				v1alpha1.IPEphemeralLabel: "true",
 			},
 		},
 		Spec: v1alpha1.IPSpec{
@@ -238,8 +226,11 @@ func (a *Allocator) release(namespace string, addr netip.Addr, claimRef v1alpha1
 			return nil
 		}
 
-		// If the IP is controlled, we assume it to be ephemeral.
-		if metav1.GetControllerOf(ip) != nil {
+		// If the IP is labelled as ephemeral or has a legacy controller
+		// OwnerReference, delete it. The OwnerReference check provides
+		// backward compatibility for IPs created before the switch to
+		// label-based ephemeral tracking.
+		if ip.Labels[v1alpha1.IPEphemeralLabel] == "true" || metav1.GetControllerOf(ip) != nil {
 			return a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{ResourceVersion: &ip.ResourceVersion},
 			})
@@ -280,9 +271,8 @@ func (dry dryRunAllocator) Allocate(namespace string, claimRef v1alpha1.IPClaimR
 func (dry dryRunAllocator) AllocateNext(
 	namespace string,
 	claimRef v1alpha1.IPClaimRef,
-	version, kind string,
 ) (netip.Addr, error) {
-	return dry.real.allocateNext(namespace, claimRef, version, kind, true)
+	return dry.real.allocateNext(namespace, claimRef, true)
 }
 
 func (dry dryRunAllocator) Release(namespace string, ip netip.Addr, claimRef v1alpha1.IPClaimRef) error {
@@ -296,7 +286,7 @@ func (dry dryRunAllocator) DryRun() Interface {
 type Interface interface {
 	IPFamily() corev1.IPFamily
 	Allocate(namespace string, claimRef v1alpha1.IPClaimRef, ip netip.Addr) error
-	AllocateNext(namespace string, claimRef v1alpha1.IPClaimRef, version, kind string) (netip.Addr, error)
+	AllocateNext(namespace string, claimRef v1alpha1.IPClaimRef) (netip.Addr, error)
 	Release(namespace string, ip netip.Addr, claimRef v1alpha1.IPClaimRef) error
 	DryRun() Interface
 }

--- a/internal/registry/ipallocator/ipallocator.go
+++ b/internal/registry/ipallocator/ipallocator.go
@@ -226,11 +226,8 @@ func (a *Allocator) release(namespace string, addr netip.Addr, claimRef v1alpha1
 			return nil
 		}
 
-		// If the IP is labelled as ephemeral or has a legacy controller
-		// OwnerReference, delete it. The OwnerReference check provides
-		// backward compatibility for IPs created before the switch to
-		// label-based ephemeral tracking.
-		if ip.Labels[v1alpha1.IPEphemeralLabel] == "true" || metav1.GetControllerOf(ip) != nil {
+		// If the IP is labeled as ephemeral, delete it.
+		if ip.Labels[v1alpha1.IPEphemeralLabel] == "true" {
 			return a.client.IPs(namespace).Delete(context.Background(), ip.Name, metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{ResourceVersion: &ip.ResourceVersion},
 			})

--- a/internal/registry/loadbalancer/storage.go
+++ b/internal/registry/loadbalancer/storage.go
@@ -155,7 +155,6 @@ func NewStorage(
 		allocators: ipallocator.NewAllocators(
 			allocatorByFamily,
 			v1alpha1.SchemeGroupVersion,
-			"LoadBalancer",
 			"loadbalancers",
 			GetLoadBalancerIPAllocatorAccessor,
 		),

--- a/internal/registry/natgateway/storage.go
+++ b/internal/registry/natgateway/storage.go
@@ -142,7 +142,6 @@ func NewStorage(
 		allocators: ipallocator.NewAllocators(
 			allocByIPFamily,
 			v1alpha1.SchemeGroupVersion,
-			"NATGateway",
 			"natgateways",
 			GetNATGatewayIPAllocatorAccessor,
 		),

--- a/internal/registry/networkinterface/storage.go
+++ b/internal/registry/networkinterface/storage.go
@@ -142,7 +142,6 @@ func NewStorage(
 		allocators: ipallocator.NewAllocators(
 			allocatorByFamily,
 			v1alpha1.SchemeGroupVersion,
-			"NetworkInterface",
 			"networkinterfaces",
 			GetNetworkInterfaceIPAllocatorAccessor,
 		),


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to ignore additional development directories.

* **Refactor**
  * Improved IP allocation and release reliability with better retry and ownership handling.
  * Ephemeral IPs are now marked with a dedicated ephemeral label for clearer lifecycle management.

* **New Features**
  * Added a startup migration that converts ephemeral IPs by removing owner references and applying the ephemeral label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #457 