### PR TITLE
Fix updating DaemonSet instances on port changes

### DIFF
--- a/internal/controllers/daemonset_controller.go
+++ b/internal/controllers/daemonset_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/ironcore-dev/controller-utils/metautils"
 	"github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
+	"github.com/ironcore-dev/ironcore-net/apimachinery/equality"
 	"github.com/ironcore-dev/ironcore-net/internal/nodeaffinity"
 	"github.com/ironcore-dev/ironcore-net/utils/controller"
 	"github.com/ironcore-dev/ironcore-net/utils/expectations"
@@ -72,12 +73,14 @@ func (r *DaemonSetReconciler) delete(
 }
 
 func (r *DaemonSetReconciler) instanceNeedsUpdate(ds *v1alpha1.DaemonSet, inst *v1alpha1.Instance) bool {
-	return !slices.Equal(inst.Spec.IPs, ds.Spec.Template.Spec.IPs)
+	return !slices.Equal(inst.Spec.IPs, ds.Spec.Template.Spec.IPs) ||
+		!equality.Semantic.DeepEqual(inst.Spec.LoadBalancerPorts, ds.Spec.Template.Spec.LoadBalancerPorts)
 }
 
 func (r *DaemonSetReconciler) updateInstance(ctx context.Context, ds *v1alpha1.DaemonSet, inst *v1alpha1.Instance) error {
 	base := inst.DeepCopy()
 	inst.Spec.IPs = ds.Spec.Template.Spec.IPs
+	inst.Spec.LoadBalancerPorts = ds.Spec.Template.Spec.LoadBalancerPorts
 	return r.Patch(ctx, inst, client.StrategicMergeFrom(base))
 }
 

--- a/internal/controllers/daemonset_controller_test.go
+++ b/internal/controllers/daemonset_controller_test.go
@@ -90,6 +90,27 @@ var _ = Describe("DaemonSetController", func() {
 			client.InNamespace(ns.Name),
 		)).Should(HaveField("Items", HaveEach(HaveField("Spec.IPs", []net.IP{net.MustParseIP("192.168.178.1")}))))
 
+		By("updating the daemon set template ports")
+		protocol := corev1.ProtocolTCP
+		Eventually(Update(ds, func() {
+			ds.Spec.Template.Spec.LoadBalancerPorts = []v1alpha1.LoadBalancerPort{
+				{
+					Protocol: &protocol,
+					Port:     80,
+				},
+			}
+		})).Should(Succeed())
+
+		By("waiting until the instance IPs are updated")
+		Eventually(ObjectList(&v1alpha1.InstanceList{},
+			client.InNamespace(ns.Name),
+		)).Should(HaveField("Items", HaveEach(HaveField("Spec.LoadBalancerPorts", []v1alpha1.LoadBalancerPort{
+			{
+				Protocol: &protocol,
+				Port:     80,
+			},
+		}))))
+
 		By("deleting the instances")
 		Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.Instance{}, client.InNamespace(ns.Name))).To(Succeed())
 


### PR DESCRIPTION
* Adapt `instanceNeedsUpdate` to also check `LoadBalancerPorts` of the instance
* Extend test case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Instances now properly detect and synchronize load balancer port configurations from DaemonSet templates alongside IP address updates, ensuring complete consistency across managed infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->