### PR TITLE
Update metalnet load balancers on instance updates

### DIFF
--- a/metalnetlet/controllers/common.go
+++ b/metalnetlet/controllers/common.go
@@ -9,8 +9,13 @@ import (
 	"strings"
 
 	"github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
+	metalnetv1alpha1 "github.com/ironcore-dev/metalnet/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/conversion"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/third_party/forked/golang/reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -67,4 +72,28 @@ func GetMetalnetNode(ctx context.Context, partitionName string, metalnetClient c
 		return nil, nil
 	}
 	return metalnetNode, nil
+}
+
+// MetalnetEqualities checks whether metalnet types are semantically equal.
+// It uses equality.Semantic as baseline and adds custom functions on top.
+var MetalnetEqualities conversion.Equalities
+
+func init() {
+	base := make(reflect.Equalities)
+	for k, v := range equality.Semantic.Equalities {
+		base[k] = v
+	}
+	MetalnetEqualities = conversion.Equalities{Equalities: base}
+	utilruntime.Must(AddFuncs(MetalnetEqualities))
+}
+
+func AddFuncs(equality conversion.Equalities) error {
+	return equality.AddFuncs(
+		func(a, b metalnetv1alpha1.IP) bool {
+			return a == b
+		},
+		func(a, b metalnetv1alpha1.IPPrefix) bool {
+			return a == b
+		},
+	)
 }

--- a/metalnetlet/controllers/instance_controller.go
+++ b/metalnetlet/controllers/instance_controller.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -134,6 +135,47 @@ func (r *InstanceReconciler) getMetalnetLoadBalancersForLoadBalancerInstance(
 	return metalnetLoadBalancerList.Items, nil
 }
 
+func (r *InstanceReconciler) metalnetLoadBalancerSpec(
+	inst *v1alpha1.Instance,
+	networkUID types.UID,
+	metalnetNodeName string,
+	metalnetLoadBalancerType metalnetv1alpha1.LoadBalancerType,
+	ip net.IP,
+) *metalnetv1alpha1.LoadBalancerSpec {
+	return &metalnetv1alpha1.LoadBalancerSpec{
+		NetworkRef: corev1.LocalObjectReference{Name: string(networkUID)},
+		LBtype:     metalnetLoadBalancerType,
+		IPFamily:   ip.Family(),
+		IP:         ipToMetalnetIP(ip),
+		Ports:      loadBalancerPortsToMetalnetLoadBalancerPorts(inst.Spec.LoadBalancerPorts),
+		NodeName:   &metalnetNodeName,
+	}
+}
+
+func (r *InstanceReconciler) updateMetalnetLoadBalancerIfNecessary(
+	ctx context.Context,
+	inst *v1alpha1.Instance,
+	metalnetLoadBalancer *metalnetv1alpha1.LoadBalancer,
+) error {
+	desiredSpec := r.metalnetLoadBalancerSpec(
+		inst,
+		types.UID(metalnetLoadBalancer.Spec.NetworkRef.Name),
+		generic.DerefZero(metalnetLoadBalancer.Spec.NodeName),
+		metalnetLoadBalancer.Spec.LBtype,
+		metalnetIPToIP(metalnetLoadBalancer.Spec.IP),
+	)
+	if MetalnetEqualities.DeepEqual(desiredSpec, &metalnetLoadBalancer.Spec) {
+		return nil
+	}
+
+	patch := client.MergeFrom(metalnetLoadBalancer.DeepCopy())
+	metalnetLoadBalancer.Spec = *desiredSpec
+	if err := r.MetalnetClient.Patch(ctx, metalnetLoadBalancer, patch); err != nil {
+		return fmt.Errorf("updating metalnet load balancer: %w", err)
+	}
+	return nil
+}
+
 func (r *InstanceReconciler) manageMetalnetLoadBalancers(
 	ctx context.Context,
 	log logr.Logger,
@@ -168,6 +210,10 @@ func (r *InstanceReconciler) manageMetalnetLoadBalancers(
 		ip := metalnetIPToIP(metalnetLoadBalancer.Spec.IP)
 		if unsatisfiedIPs.Has(ip) {
 			unsatisfiedIPs.Delete(ip)
+
+			if err := r.updateMetalnetLoadBalancerIfNecessary(ctx, inst, &metalnetLoadBalancer); err != nil {
+				errs = append(errs, err)
+			}
 			continue
 		}
 
@@ -180,14 +226,7 @@ func (r *InstanceReconciler) manageMetalnetLoadBalancers(
 	var bumpCollisionCount bool
 	for ip := range unsatisfiedIPs {
 		metalnetLoadBalancerHash := computeMetalnetLoadBalancerHash(ip, inst.Status.CollisionCount)
-		metalnetLoadBalancerSpec := metalnetv1alpha1.LoadBalancerSpec{
-			NetworkRef: corev1.LocalObjectReference{Name: string(network.UID)},
-			LBtype:     metalnetLoadBalancerType,
-			IPFamily:   ip.Family(),
-			IP:         ipToMetalnetIP(ip),
-			Ports:      loadBalancerPortsToMetalnetLoadBalancerPorts(inst.Spec.LoadBalancerPorts),
-			NodeName:   &metalnetNodeName,
-		}
+		metalnetLoadBalancerSpec := r.metalnetLoadBalancerSpec(inst, network.UID, metalnetNodeName, metalnetLoadBalancerType, ip)
 		metalnetLoadBalancerName := string(inst.UID) + "-" + metalnetLoadBalancerHash
 		metalnetLoadBalancer := &metalnetv1alpha1.LoadBalancer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -195,7 +234,7 @@ func (r *InstanceReconciler) manageMetalnetLoadBalancers(
 				Name:      metalnetLoadBalancerName,
 				Labels:    metalnetletclient.SourceLabels(r.Scheme(), r.RESTMapper(), inst),
 			},
-			Spec: metalnetLoadBalancerSpec,
+			Spec: *metalnetLoadBalancerSpec,
 		}
 		createMetalnetLoadBalancer := metalnetLoadBalancer.DeepCopy()
 		if err := r.MetalnetClient.Create(ctx, metalnetLoadBalancer); err != nil {

--- a/metalnetlet/controllers/instance_controller_test.go
+++ b/metalnetlet/controllers/instance_controller_test.go
@@ -59,6 +59,30 @@ var _ = Describe("LoadBalancerInstanceController", func() {
 			HaveField("Spec.IP", metalnetv1alpha1.MustParseIP("10.0.0.1")),
 			HaveField("Spec.IP", metalnetv1alpha1.MustParseIP("10.0.0.2")),
 		)))
+
+		By("adding a load balancer ports")
+		Eventually(Update(inst, func() {
+			inst.Spec.LoadBalancerPorts = append(inst.Spec.LoadBalancerPorts, v1alpha1.LoadBalancerPort{
+				Protocol: &protocol,
+				Port:     1001,
+			})
+		})).Should(Succeed())
+
+		By("waiting for the metalnet load balancers to be updated")
+		consistOfExpectedPorts := ConsistOf(
+			metalnetv1alpha1.LBPort{
+				Protocol: string(protocol),
+				Port:     1000,
+			},
+			metalnetv1alpha1.LBPort{
+				Protocol: string(protocol),
+				Port:     1001,
+			},
+		)
+		Eventually(ObjectList(metalnetLoadBalancerList)).Should(HaveField("Items", ConsistOf(
+			HaveField("Spec.Ports", consistOfExpectedPorts),
+			HaveField("Spec.Ports", consistOfExpectedPorts),
+		)))
 	})
 
 	It("should recreate the metalnet load balancer if it gets deleted", func(ctx SpecContext) {


### PR DESCRIPTION
Fix missing updates metalnet load balancers when the desired spec via an instance does not match the current metalnet load balancer spec.

Add test case verifying this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load balancer configuration synchronization when instance specifications are updated.

* **Tests**
  * Enhanced test coverage for instance updates with multiple load balancer ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->