### PR TITLE
Add `NIC` state to table converter

### DIFF
--- a/internal/registry/networkinterface/tableconvertor.go
+++ b/internal/registry/networkinterface/tableconvertor.go
@@ -26,6 +26,7 @@ var (
 		{Name: "IPs", Type: "string", Description: "The IPs of the network interface"},
 		{Name: "Prefixes", Type: "string", Description: "The prefixes of the network interface"},
 		{Name: "PublicIPs", Type: "string", Description: "The public IPs of the network interface"},
+		{Name: "State", Type: "string", Description: "The state of the network interface"},
 		{Name: "Age", Type: "string", Format: "date", Description: objectMetaSwaggerDoc["creationTimestamp"]},
 	}
 )
@@ -81,6 +82,7 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 		cells = append(cells, formatIPs(nic.Spec.IPs))
 		cells = append(cells, formatPrefixes(nic.Spec.Prefixes))
 		cells = append(cells, formatPublicIPs(nic.Spec.PublicIPs))
+		cells = append(cells, nic.Status.State)
 		cells = append(cells, age)
 
 		return cells, nil


### PR DESCRIPTION
# Proposed Changes

Add missing NIC state to table converter, right now it's not obvious in which state the NIC is: 
```
NAMESPACE           NAME                                   NETWORK                                IPS        PREFIXES   PUBLICIPS                              AGE
nic                 ae4029f3-fad7-5aeb-ae68-fec1a7d45858   8ba6180d-d28d-4da6-89f2-bbbfa9243848   10.0.0.1              45.86.152.8                            3d
```
