### PR TITLE
Drop vgopath from API code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,7 @@ manifests: controller-gen ## Generate rbac objects.
 	./hack/promote-let-role.sh config/metalnetlet/apinet-rbac/role.yaml config/apiserver/rbac/metalnetlet_role.yaml apinet.ironcore.dev:system:metalnetlets
 
 .PHONY: generate
-generate: vgopath models-schema openapi-gen
-	VGOPATH=$(VGOPATH) \
+generate: models-schema openapi-gen
 	MODELS_SCHEMA=$(MODELS_SCHEMA) \
 	OPENAPI_GEN=$(OPENAPI_GEN) \
 	./hack/update-codegen.sh
@@ -333,7 +332,6 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 OPENAPI_EXTRACTOR ?= $(LOCALBIN)/openapi-extractor
 OPENAPI_GEN ?= $(LOCALBIN)/openapi-gen
-VGOPATH ?= $(LOCALBIN)/vgopath
 GEN_CRD_API_REFERENCE_DOCS ?= $(LOCALBIN)/gen-crd-api-reference-docs
 ADDLICENSE ?= $(LOCALBIN)/addlicense
 MODELS_SCHEMA ?= $(LOCALBIN)/models-schema
@@ -342,7 +340,6 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
-VGOPATH_VERSION ?= v0.1.5
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
 GEN_CRD_API_REFERENCE_DOCS_VERSION ?= v0.3.0
 ADDLICENSE_VERSION ?= v1.1.1
@@ -368,12 +365,6 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 openapi-gen: $(OPENAPI_GEN) ## Download openapi-gen locally if necessary.
 $(OPENAPI_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/openapi-gen || GOBIN=$(LOCALBIN) go install k8s.io/kube-openapi/cmd/openapi-gen
-
-.PHONY: vgopath
-vgopath: $(VGOPATH) ## Download vgopath locally if necessary.
-.PHONY: $(VGOPATH)
-$(VGOPATH): $(LOCALBIN)
-	$(call go-install-tool,$(VGOPATH),github.com/ironcore-dev/vgopath,$(VGOPATH_VERSION))
 
 .PHONY: openapi-extractor
 openapi-extractor: $(OPENAPI_EXTRACTOR) ## Download openapi-extractor locally if necessary.

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -16,18 +16,10 @@ bold="$(tput bold)"
 blue="$(tput setaf 4)"
 normal="$(tput sgr0)"
 
-
-VGOPATH="$VGOPATH"
 MODELS_SCHEMA="$MODELS_SCHEMA"
 OPENAPI_GEN="$OPENAPI_GEN"
-VIRTUAL_GOPATH="$(mktemp -d)"
-trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
 
-# Setup virtual GOPATH so the codegen tools work as expected.
-(cd "$PROJECT_ROOT"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
-
-export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
-export GOPATH="$VIRTUAL_GOPATH"
+(cd "$PROJECT_ROOT"; go mod download)
 
 CODE_GEN_DIR=$(go list -m -f '{{.Dir}}' k8s.io/code-generator)
 source "${CODE_GEN_DIR}/kube_codegen.sh"


### PR DESCRIPTION
# Proposed Changes

Use upstream `k8s.io/code-generator` (kube_codegen.sh) directly instead of synthesizing a virtual GOPATH via vgopath. The codegen tools have been module-aware for a while, so the GOPATH-style layout is no longer needed.

- Remove the VGOPATH variable, install target, and version pin from the Makefile, and drop vgopath as a prerequisite of `generate` and `proto`.
- Drop the mktemp + vgopath -o materialization and GOROOT/GOPATH exports from hack/update-codegen.sh; only `go mod download` remains so `go list -m` can resolve k8s.io/code-generator.

Generated output (`api/`, `client-go/`, `internal/apis/`) is byte-identical to before.

/ref https://github.com/ironcore-dev/ironcore/issues/1478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Simplified the code generation build process by removing an internal build tool dependency and streamlining the module download step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->