### PR TITLE
Fix NATGateway watch setup in apinetlet

### DIFF
--- a/apinetlet/controllers/natgateway_controller.go
+++ b/apinetlet/controllers/natgateway_controller.go
@@ -9,13 +9,14 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
-	netclientutils "github.com/ironcore-dev/ironcore-net/utils/client"
-	utilhandlers "github.com/ironcore-dev/ironcore-net/utils/handler"
-	"github.com/ironcore-dev/ironcore-net/utils/origin"
-
 	apinetv1alpha1 "github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
 	apinetv1alpha1ac "github.com/ironcore-dev/ironcore-net/client-go/applyconfigurations/core/v1alpha1"
 	ironcorenet "github.com/ironcore-dev/ironcore-net/client-go/ironcorenet/versioned"
+	netclientutils "github.com/ironcore-dev/ironcore-net/utils/client"
+	utilhandlers "github.com/ironcore-dev/ironcore-net/utils/handler"
+	"github.com/ironcore-dev/ironcore-net/utils/origin"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
@@ -217,6 +218,24 @@ func (r *NATGatewayReconciler) updateNATGatewayStatus(
 	return r.Status().Patch(ctx, natGateway, client.StrategicMergeFrom(base))
 }
 
+func (r *NATGatewayReconciler) enqueueNATGatewayByNetwork() handler.TypedEventHandler[client.Object, reconcile.Request] {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		network := obj.(*networkingv1alpha1.Network)
+		natGatewayList := &networkingv1alpha1.NATGatewayList{}
+		if err := r.List(ctx, natGatewayList, client.InNamespace(network.Namespace)); err != nil {
+			ctrl.LoggerFrom(ctx).Error(err, "Failed to list NAT gateways for network", "Network", network.Name)
+			return nil
+		}
+		var req []ctrl.Request
+		for _, natGateway := range natGatewayList.Items {
+			if natGateway.Spec.NetworkRef.Name == network.Name {
+				req = append(req, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&natGateway)})
+			}
+		}
+		return req
+	})
+}
+
 func (r *NATGatewayReconciler) SetupWithManager(mgr ctrl.Manager, apiNetCache cache.Cache) error {
 	log := ctrl.Log.WithName("natgateway").WithName("setup")
 
@@ -227,6 +246,10 @@ func (r *NATGatewayReconciler) SetupWithManager(mgr ctrl.Manager, apiNetCache ca
 				predicates.ResourceHasFilterLabel(log, r.WatchFilterValue),
 				predicates.ResourceIsNotExternallyManaged(log),
 			),
+		).
+		Watches(
+			&networkingv1alpha1.Network{},
+			r.enqueueNATGatewayByNetwork(),
 		).
 		WatchesRawSource(
 			source.Kind[client.Object](

--- a/apinetlet/controllers/natgateway_controller_test.go
+++ b/apinetlet/controllers/natgateway_controller_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
@@ -57,6 +58,53 @@ var _ = Describe("NATGatewayController", func() {
 				StemFrom(NATGatewayOrigin, natGateway),
 				BeControlledBy(apiNetNATGateway),
 			),
+		)
+	})
+
+	It("should reconcile natgateway when network is created after natgateway", func(ctx SpecContext) {
+		By("creating a nat gateway whose network does not yet exist")
+		natGateway := &networkingv1alpha1.NATGateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "nat-gateway-",
+			},
+			Spec: networkingv1alpha1.NATGatewaySpec{
+				Type:       networkingv1alpha1.NATGatewayTypePublic,
+				IPFamily:   corev1.IPv4Protocol,
+				NetworkRef: corev1.LocalObjectReference{Name: "foo"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, natGateway)).To(Succeed())
+
+		By("asserting no APINet NAT gateway is created while the network is missing")
+		apiNetNATGateway := &v1alpha1.NATGateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: apiNetNs.Name,
+				Name:      string(natGateway.UID),
+			},
+		}
+		Consistently(Get(apiNetNATGateway)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("creating the referenced network")
+		network := &networkingv1alpha1.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      "foo",
+			},
+		}
+		Expect(k8sClient.Create(ctx, network)).To(Succeed())
+
+		By("waiting for the APINet NAT gateway to appear once the network exists")
+		Eventually(Object(apiNetNATGateway)).Should(StemFrom(NATGatewayOrigin, natGateway))
+
+		By("simulating the autoscaler by requesting one public IP on the APINet NAT gateway")
+		Eventually(Update(apiNetNATGateway, func() {
+			apiNetNATGateway.Spec.IPs = []v1alpha1.NATGatewayIP{{Name: "ip-1"}}
+		})).Should(Succeed())
+
+		By("waiting for the NAT gateway status IPs to be populated")
+		Eventually(Object(natGateway)).Should(
+			HaveField("Status.IPs", Not(BeEmpty())),
 		)
 	})
 })


### PR DESCRIPTION
# Proposed Changes

The NATGateway reconciler now also reacts on changes to networks to avoid stuck gateways because the corrsponding network was not created before the gateway object.

Fixes #506 