### PR TITLE
Fix load balancer instance cleanup & enhance tests

### DIFF
--- a/apinetlet/controllers/loadbalancer_controller.go
+++ b/apinetlet/controllers/loadbalancer_controller.go
@@ -359,8 +359,16 @@ func (r *LoadBalancerReconciler) applyAPINetLoadBalancer(ctx context.Context, lo
 				uniqueDsts[dst.TargetRef.NodeRef.Name] = dst
 			}
 
+			// Build up sorted node names to make apply deterministic.
+			nodeNames := make([]string, 0, len(uniqueDsts))
+			for dstName := range uniqueDsts {
+				nodeNames = append(nodeNames, dstName)
+			}
+			slices.Sort(nodeNames)
+
 			nodeSelector := apinetv1alpha1ac.NodeSelector()
-			for dstName, dst := range uniqueDsts {
+			for _, dstName := range nodeNames {
+				dst := uniqueDsts[dstName]
 				if dst.TargetRef != nil {
 					nodeSelector.WithNodeSelectorTerms(apinetv1alpha1ac.NodeSelectorTerm().WithMatchFields(apinetv1alpha1ac.NodeSelectorRequirement().
 						WithKey("metadata.name").

--- a/apinetlet/controllers/loadbalancer_controller_test.go
+++ b/apinetlet/controllers/loadbalancer_controller_test.go
@@ -259,7 +259,7 @@ var _ = Describe("LoadBalancerController", func() {
 		)
 	})
 
-	It("should manage the APINet load balancer and its node affintity", func(ctx SpecContext) {
+	It("should manage the APINet load balancer and its node affinity + routing", func(ctx SpecContext) {
 		By("creating a load balancer")
 		loadBalancer := &networkingv1alpha1.LoadBalancer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -372,5 +372,35 @@ var _ = Describe("LoadBalancerController", func() {
 				}),
 			}))),
 		)
+
+		By("waiting for the APINet load balancer routing")
+		apiNetLoadBalancerRouting := &v1alpha1.LoadBalancerRouting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: apiNetNs.Name,
+				Name:      string(loadBalancer.UID),
+			},
+		}
+		Eventually(Object(apiNetLoadBalancerRouting)).Should(HaveField("Destinations", ConsistOf(
+			v1alpha1.LoadBalancerDestination{
+				IP: net.MustParseIP("192.168.0.1"),
+				TargetRef: &v1alpha1.LoadBalancerTargetRef{
+					UID:  "first-metalnet-nic-uid",
+					Name: "first-apinet-nic-name",
+					NodeRef: corev1.LocalObjectReference{
+						Name: "first-node-name",
+					},
+				},
+			},
+			v1alpha1.LoadBalancerDestination{
+				IP: net.MustParseIP("192.168.0.2"),
+				TargetRef: &v1alpha1.LoadBalancerTargetRef{
+					UID:  "second-metalnet-nic-uid",
+					Name: "second-apinet-nic-name",
+					NodeRef: corev1.LocalObjectReference{
+						Name: "second-node-name",
+					},
+				},
+			},
+		)))
 	})
 })

--- a/cmd/metalnetlet/main.go
+++ b/cmd/metalnetlet/main.go
@@ -299,6 +299,7 @@ func main() {
 	if err := (&controllers.InstanceReconciler{
 		Client:            mgr.GetClient(),
 		MetalnetClient:    metalnetCluster.GetClient(),
+		MetalnetAPIReader: metalnetCluster.GetAPIReader(),
 		PartitionName:     name,
 		MetalnetNamespace: metalnetNamespace,
 	}).SetupWithManager(mgr, metalnetCluster.GetCache()); err != nil {

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.32.0 h1:Hw7s2pVrQo/8Yz5N77qdnpHaoc+c6cC9WIV1Jce+J6E=
 github.com/onsi/ginkgo/v2 v2.32.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.42.1 h1:iN1rCUX+44NZ1Dc97MPoeFYbFR0vh8zxoxMFwKdyZ6I=

--- a/metalnetlet/controllers/controllers_suite_test.go
+++ b/metalnetlet/controllers/controllers_suite_test.go
@@ -173,6 +173,7 @@ func SetupTest(metalnetNs *corev1.Namespace) {
 		Expect((&InstanceReconciler{
 			Client:            k8sManager.GetClient(),
 			MetalnetClient:    k8sManager.GetClient(),
+			MetalnetAPIReader: k8sManager.GetAPIReader(),
 			PartitionName:     partitionName,
 			MetalnetNamespace: metalnetNs.Name,
 		}).SetupWithManager(k8sManager, k8sManager.GetCache())).To(Succeed())
@@ -222,6 +223,7 @@ func SetupTestWithNetworkPeeringDisabled(metalnetNs *corev1.Namespace) {
 		Expect((&InstanceReconciler{
 			Client:            k8sManager.GetClient(),
 			MetalnetClient:    k8sManager.GetClient(),
+			MetalnetAPIReader: k8sManager.GetAPIReader(),
 			PartitionName:     partitionName,
 			MetalnetNamespace: metalnetNs.Name,
 		}).SetupWithManager(k8sManager, k8sManager.GetCache())).To(Succeed())

--- a/metalnetlet/controllers/instance_controller.go
+++ b/metalnetlet/controllers/instance_controller.go
@@ -44,7 +44,8 @@ var (
 
 type InstanceReconciler struct {
 	client.Client
-	MetalnetClient client.Client
+	MetalnetClient    client.Client
+	MetalnetAPIReader client.Reader
 
 	PartitionName string
 
@@ -103,7 +104,7 @@ func (r *InstanceReconciler) deleteMetalnetLoadBalancersByLoadBalancerInstanceAn
 		return false, err
 	}
 
-	return netclientutils.AnyExists(ctx, r.MetalnetClient, &metalnetv1alpha1.LoadBalancer{},
+	return netclientutils.AnyExists(ctx, r.MetalnetClient.Scheme(), r.MetalnetAPIReader, &metalnetv1alpha1.LoadBalancer{},
 		client.InNamespace(r.MetalnetNamespace),
 		&netclientutils.StemmingFrom{Origin: InstanceOrigin, Source: inst},
 	)

--- a/metalnetlet/controllers/instance_controller_test.go
+++ b/metalnetlet/controllers/instance_controller_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
@@ -125,5 +126,50 @@ var _ = Describe("LoadBalancerInstanceController", func() {
 			Should(HaveField("Items", ContainElement(
 				HaveField("UID", Not(Equal(metalnetLoadBalancer.UID))),
 			)))
+	})
+
+	It("should correctly finalize and delete an instance", func(ctx SpecContext) {
+		By("creating a load balancer instance")
+		protocol := corev1.ProtocolTCP
+		inst := &v1alpha1.Instance{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "lb-",
+			},
+			Spec: v1alpha1.InstanceSpec{
+				Type:             v1alpha1.InstanceTypeLoadBalancer,
+				LoadBalancerType: v1alpha1.LoadBalancerTypePublic,
+				NetworkRef:       corev1.LocalObjectReference{Name: network.Name},
+				IPs:              []net.IP{net.MustParseIP("10.0.0.1")},
+				NodeRef: &corev1.LocalObjectReference{
+					Name: PartitionNodeName(partitionName, metalnetNode.Name),
+				},
+				LoadBalancerPorts: []v1alpha1.LoadBalancerPort{
+					{
+						Protocol: &protocol,
+						Port:     1000,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, inst)).To(Succeed())
+
+		By("waiting for the load balancer instance to have a finalizer")
+		Eventually(Object(inst)).Should(HaveField("Finalizers", ConsistOf(PartitionFinalizer(partitionName))))
+
+		By("waiting for the metalnet load balancer to appear")
+		metalnetLoadBalancerList := &metalnetv1alpha1.LoadBalancerList{}
+		Eventually(ObjectList(metalnetLoadBalancerList, client.InNamespace(metalnetNs.Name))).
+			Should(HaveField("Items", HaveLen(1)))
+
+		By("deleting the load balancer instance")
+		Expect(k8sClient.Delete(ctx, inst)).To(Succeed())
+
+		By("waiting for the instance to be gone")
+		Eventually(Get(inst)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("asserting there are no metalnet load balancers left")
+		Eventually(ObjectList(metalnetLoadBalancerList, client.InNamespace(metalnetNs.Name))).
+			Should(HaveField("Items", BeEmpty()))
 	})
 })

--- a/utils/client/client.go
+++ b/utils/client/client.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -70,8 +71,8 @@ func (s *StemmingFromKey) Matches(obj client.Object) bool {
 	return s.Origin.StemsFromKey(obj, s.SourceKey)
 }
 
-func AnyExists(ctx context.Context, c client.Client, obj client.Object, opts ...client.ListOption) (bool, error) {
-	_, list, err := metautils.NewListForObject(c.Scheme(), obj)
+func AnyExists(ctx context.Context, scheme *runtime.Scheme, c client.Reader, obj client.Object, opts ...client.ListOption) (bool, error) {
+	_, list, err := metautils.NewListForObject(scheme, obj)
 	if err != nil {
 		return false, fmt.Errorf("error creating new list for object: %w", err)
 	}


### PR DESCRIPTION
* For metalnetlet: Fix the invocation of `AnyExists` in metalnetlet instance controller to use the MetalnetletAPIReader (caching client does not support continue)
* Create test case verifying metalnetlet load balancers are cleaned up on instance finalization
* Enhance test case for apinetlet load balancer controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made load balancer node-affinity generation deterministic across reconciliations.
  * Strengthened load balancer routing validation, including destination-to-node mappings.
  * Improved deletion finalization for load balancer instances, ensuring related load balancers are removed.
  * Enhanced “resource exists” checks during deletion workflows.
* **Tests**
  * Added coverage verifying instance finalization and cleanup behavior.
  * Expanded load balancer routing tests to also validate created routing destinations and targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->