### PR TITLE
Fix Load Balancer Routing Owner Ref

### DIFF
--- a/apinetlet/controllers/loadbalancer_controller.go
+++ b/apinetlet/controllers/loadbalancer_controller.go
@@ -224,10 +224,10 @@ func (r *LoadBalancerReconciler) prepareApiNetDestinations(ctx context.Context, 
 
 func (r *LoadBalancerReconciler) manageAPINetLoadBalancerRouting(ctx context.Context, loadBalancer *networkingv1alpha1.LoadBalancer, apiNetLoadBalancer *apinetv1alpha1.LoadBalancer, apiNetDsts []apinetv1alpha1.LoadBalancerDestination) error {
 	ownerRef := metav1apply.OwnerReference().
-		WithAPIVersion(networkingv1alpha1.SchemeGroupVersion.String()).
+		WithAPIVersion(apinetv1alpha1.SchemeGroupVersion.String()).
 		WithKind("LoadBalancer").
-		WithName(loadBalancer.Name).
-		WithUID(loadBalancer.UID).
+		WithName(apiNetLoadBalancer.Name).
+		WithUID(apiNetLoadBalancer.UID).
 		WithController(true).
 		WithBlockOwnerDeletion(true)
 

--- a/apinetlet/controllers/loadbalancer_controller_test.go
+++ b/apinetlet/controllers/loadbalancer_controller_test.go
@@ -380,27 +380,39 @@ var _ = Describe("LoadBalancerController", func() {
 				Name:      string(loadBalancer.UID),
 			},
 		}
-		Eventually(Object(apiNetLoadBalancerRouting)).Should(HaveField("Destinations", ConsistOf(
-			v1alpha1.LoadBalancerDestination{
-				IP: net.MustParseIP("192.168.0.1"),
-				TargetRef: &v1alpha1.LoadBalancerTargetRef{
-					UID:  "first-metalnet-nic-uid",
-					Name: "first-apinet-nic-name",
-					NodeRef: corev1.LocalObjectReference{
-						Name: "first-node-name",
+		Eventually(Object(apiNetLoadBalancerRouting)).Should(
+			SatisfyAll(
+				HaveField("OwnerReferences", []metav1.OwnerReference{
+					{
+						APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+						Kind:               "LoadBalancer",
+						Name:               apiNetLoadBalancer.Name,
+						UID:                apiNetLoadBalancer.UID,
+						Controller:         new(true),
+						BlockOwnerDeletion: new(true),
 					},
-				},
-			},
-			v1alpha1.LoadBalancerDestination{
-				IP: net.MustParseIP("192.168.0.2"),
-				TargetRef: &v1alpha1.LoadBalancerTargetRef{
-					UID:  "second-metalnet-nic-uid",
-					Name: "second-apinet-nic-name",
-					NodeRef: corev1.LocalObjectReference{
-						Name: "second-node-name",
+				}),
+				HaveField("Destinations", ConsistOf(
+					v1alpha1.LoadBalancerDestination{
+						IP: net.MustParseIP("192.168.0.1"),
+						TargetRef: &v1alpha1.LoadBalancerTargetRef{
+							UID:  "first-metalnet-nic-uid",
+							Name: "first-apinet-nic-name",
+							NodeRef: corev1.LocalObjectReference{
+								Name: "first-node-name",
+							},
+						},
 					},
-				},
-			},
-		)))
+					v1alpha1.LoadBalancerDestination{
+						IP: net.MustParseIP("192.168.0.2"),
+						TargetRef: &v1alpha1.LoadBalancerTargetRef{
+							UID:  "second-metalnet-nic-uid",
+							Name: "second-apinet-nic-name",
+							NodeRef: corev1.LocalObjectReference{
+								Name: "second-node-name",
+							},
+						},
+					},
+				))))
 	})
 })


### PR DESCRIPTION
In a recent commit, the owner ref was accidentally set to the networking load balancer, causing the routings to be continuously cleaned up by the k8s garbage collector.

This fixes the ref to correctly point at the apinet load balancer again and extends a test case to verify this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ownership tracking for generated load balancer routing resources.
  * Ensured routing resources are properly associated with the corresponding APINet load balancer.

* **Tests**
  * Added validation for routing resource ownership metadata and controller settings.
  * Continued verifying that destination mappings are propagated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->